### PR TITLE
[FE] 메인 페이지 및 검색 페이지 CSS 레이아웃 수정

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -11,7 +11,8 @@ const SContainer = styled.div`
 const SMain = styled.main`
   min-height: calc(100vh - 235px); // header 60 + footer 175
   margin: 0 auto;
-  max-width: 1920px; // 추후 논의 필요
+  padding-bottom: 200px;
+  max-width: 1280px;
 `;
 
 const Layout = () => {

--- a/client/src/components/Main/RecipeItem/RecipeItem.tsx
+++ b/client/src/components/Main/RecipeItem/RecipeItem.tsx
@@ -6,9 +6,8 @@ import { AiFillStar } from "react-icons/ai";
 const SRecipeLayout = styled.div`
   display: flex;
   flex-direction: column;
-  width: 350px;
-  height: 330px;
-  margin: 1rem;
+  width: 400px;
+  height: 338px;
   border: 1px solid var(--pale-gray);
   border-radius: 5px;
 

--- a/client/src/components/Main/RecipeItem/RecipeItemList.tsx
+++ b/client/src/components/Main/RecipeItem/RecipeItemList.tsx
@@ -3,15 +3,12 @@ import RecipeItem from "./RecipeItem";
 
 const SItemListLayout = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   grid-gap: 1rem;
   place-items: center;
+  margin-top: 3rem;
 
   // 임시 반응형 작업 (추후 중단점 수정 필요)
-  @media screen and (max-width: 1700px) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
   @media screen and (max-width: 1300px) {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -89,6 +86,42 @@ const dummyData = [
       "https://ottogi.okitchen.co.kr/pds/upfile/2020-08-25_427863666[2].jpg",
     link: "/",
     rating: 3,
+  },
+  {
+    id: 9,
+    recipeTitle: "햄마요 덮밥",
+    tag: ["햄", "마요네즈", "밥"],
+    recipeImg:
+      "https://ottogi.okitchen.co.kr/pds/upfile/2020-08-25_427865954[12].jpg",
+    link: "/",
+    rating: 5,
+  },
+  {
+    id: 10,
+    recipeTitle: "콘치즈",
+    tag: ["치즈", "안주"],
+    recipeImg:
+      "https://ottogi.okitchen.co.kr/pds/upfile/2020-08-25_427863666[8].jpg",
+    link: "/",
+    rating: 2,
+  },
+  {
+    id: 11,
+    recipeTitle: "토마토 냉파스타",
+    tag: ["면", "토마토"],
+    recipeImg:
+      "https://ottogi.okitchen.co.kr/pds/upfile/2020-08-25_427865954[2].jpg",
+    link: "/",
+    rating: 4.5,
+  },
+  {
+    id: 12,
+    recipeTitle: "카레 비프 스튜",
+    tag: ["카레", "소고기", "메인"],
+    recipeImg:
+      "https://ottogi.okitchen.co.kr/pds/upfile/2020-08-25_427863666[2].jpg",
+    link: "/",
+    rating: 2,
   },
 ];
 

--- a/client/src/components/Main/RecipeItem/RecipeItemList.tsx
+++ b/client/src/components/Main/RecipeItem/RecipeItemList.tsx
@@ -4,7 +4,7 @@ import RecipeItem from "./RecipeItem";
 const SItemListLayout = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-gap: 1rem;
+  grid-gap: 64px 40px;
   place-items: center;
   margin-top: 3rem;
 

--- a/client/src/components/Search/SearchBar.tsx
+++ b/client/src/components/Search/SearchBar.tsx
@@ -46,7 +46,6 @@ const SSearchWord = styled.div`
 
 const STagArea = styled.div`
   margin: 0 20px;
-  border-bottom: 1px solid var(--deep-green);
 `;
 
 const SearchBar = () => {

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -11,12 +11,10 @@ const SMainLayout = styled.main`
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding-bottom: 100px;
 `;
 
 const SSectionLayout = styled.section`
   margin: 70px 0;
-  padding: 0 150px;
 
   // 임시 반응형 작업 (추후 중단점 수정 필요)
   @media screen and (max-width: 1000px) {

--- a/client/src/pages/Search/Search.tsx
+++ b/client/src/pages/Search/Search.tsx
@@ -12,7 +12,6 @@ const SSearchLayout = styled.section`
 const SSearchResult = styled.div`
   width: 100%;
   margin: 70px 0;
-  padding: 0 150px;
 
   // 임시 반응형 작업 (추후 중단점 수정 필요)
   @media screen and (max-width: 1000px) {


### PR DESCRIPTION
## 1. 작업 내용
![image](https://user-images.githubusercontent.com/59650985/192453956-5da4cfb1-3fcd-4b61-b113-1cafa3e85cd2.png)
![image](https://user-images.githubusercontent.com/59650985/192454075-fddb963f-c757-428d-9ed8-809b2cff89a1.png)
- 공통 레이아웃
  - max-width를 1280px로 확정
  - padding-bottom을 200px로 지정

- 레시피 아이템 및 레시피 아이템 리스트 
  - 디자인 시안에 있는 사이즈와 동일하게 px 변경 작업
  - 디자인 시안과 동일하게 gap 부여 및 한 줄에 아이템 3개 노출

- 검색바 컴포넌트 내 인기 검색어
  - border-bottom 제거 (디자인 시안에는 있지만, 인기 검색어만 노출할 것이므로 구분선 제거했습니다.)

- 메인 페이지 및 검색 페이지
  - padding 제거

## 2. 전달 사항
![image](https://user-images.githubusercontent.com/59650985/192456759-5eb68dc9-73ad-4d04-a314-fba2f40f782c.png)
- 공통 레이아웃의 padding-bottom을 푸터와 어느 정도 떨어뜨려 놓기 위해 200px로 지정하였는데, 간격 조정이 필요하다면 수정하도록 하겠습니다.
