### PR TITLE
Feat/be/31 service layer

### DIFF
--- a/server/src/main/java/run/ward/mmz/domain/account/Account.java
+++ b/server/src/main/java/run/ward/mmz/domain/account/Account.java
@@ -43,7 +43,6 @@ public class Account extends Auditable {
     @Column(nullable = false)
     private Role role;
 
-    @JsonIgnore
     @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Recipe> recipes = new ArrayList<>();
     @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)

--- a/server/src/main/java/run/ward/mmz/domain/account/Account.java
+++ b/server/src/main/java/run/ward/mmz/domain/account/Account.java
@@ -1,6 +1,7 @@
 package run.ward.mmz.domain.account;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import run.ward.mmz.domain.auditable.Auditable;
 import run.ward.mmz.domain.post.Bookmark;
@@ -42,6 +43,7 @@ public class Account extends Auditable {
     @Column(nullable = false)
     private Role role;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Recipe> recipes = new ArrayList<>();
     @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)

--- a/server/src/main/java/run/ward/mmz/domain/account/Account.java
+++ b/server/src/main/java/run/ward/mmz/domain/account/Account.java
@@ -78,8 +78,9 @@ public class Account extends Auditable {
     public void addBookmarks(Bookmark bookmark) {
         if(!bookmarks.contains(bookmark)) {
             bookmarks.add(bookmark);
+            bookmark.setOwner(this);
         }
-        bookmark.setOwner(this);
+
     }
 
     public void removeBookmarks(Bookmark bookmark) {
@@ -90,15 +91,17 @@ public class Account extends Auditable {
     public void addReview(Review review){
         if(!reviews.contains(review)){
             reviews.add(review);
+            review.setOwner(this);
         }
-        review.setOwner(this);
+
     }
 
     public void addRecipe(Recipe recipe){
         if(!recipes.contains(recipe)) {
             recipes.add(recipe);
+            recipe.setOwner(this);
         }
-        recipe.setOwner(this);
+
     }
 
     @JsonIgnore

--- a/server/src/main/java/run/ward/mmz/domain/account/Account.java
+++ b/server/src/main/java/run/ward/mmz/domain/account/Account.java
@@ -5,9 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import run.ward.mmz.domain.auditable.Auditable;
 import run.ward.mmz.domain.file.Files;
-import run.ward.mmz.domain.post.Bookmark;
-import run.ward.mmz.domain.post.Recipe;
-import run.ward.mmz.domain.post.Review;
+import run.ward.mmz.domain.post.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -84,6 +82,11 @@ public class Account extends Auditable {
         bookmark.setOwner(this);
     }
 
+    public void removeBookmarks(Bookmark bookmark) {
+        bookmarks.remove(bookmark);
+    }
+
+
     public void addReview(Review review){
         if(!reviews.contains(review)){
             reviews.add(review);
@@ -96,6 +99,18 @@ public class Account extends Auditable {
             recipes.add(recipe);
         }
         recipe.setOwner(this);
+    }
+
+    @JsonIgnore
+    public List<Recipe> getRecipeList(){
+
+        List<Recipe> recipeList = new ArrayList<>();
+
+        for(Bookmark bookmark : this.bookmarks) {
+            recipeList.add(bookmark.getRecipe());
+        }
+
+        return recipeList;
     }
 
 }

--- a/server/src/main/java/run/ward/mmz/domain/account/Account.java
+++ b/server/src/main/java/run/ward/mmz/domain/account/Account.java
@@ -4,6 +4,7 @@ package run.ward.mmz.domain.account;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import run.ward.mmz.domain.auditable.Auditable;
+import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.Bookmark;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
@@ -38,6 +39,12 @@ public class Account extends Auditable {
 
     @Column
     private String picture;
+
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "profileId")
+    private Files imgProfile;
+
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/server/src/main/java/run/ward/mmz/domain/account/Account.java
+++ b/server/src/main/java/run/ward/mmz/domain/account/Account.java
@@ -77,18 +77,24 @@ public class Account extends Auditable {
     }
 
 
-    public void addBookmarks(Bookmark bookmark){
-        bookmarks.add(bookmark);
+    public void addBookmarks(Bookmark bookmark) {
+        if(!bookmarks.contains(bookmark)) {
+            bookmarks.add(bookmark);
+        }
         bookmark.setOwner(this);
     }
 
     public void addReview(Review review){
-        reviews.add(review);
+        if(!reviews.contains(review)){
+            reviews.add(review);
+        }
         review.setOwner(this);
     }
 
     public void addRecipe(Recipe recipe){
-        recipes.add(recipe);
+        if(!recipes.contains(recipe)) {
+            recipes.add(recipe);
+        }
         recipe.setOwner(this);
     }
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
@@ -48,12 +48,10 @@ public class Bookmark extends Auditable {
     }
 
     protected void removeRecipe(@NotNull Recipe recipe){
-        this.recipe = null;
         recipe.removeBookmarks(this);
     }
 
     public void removeOwner(@NotNull Account owner){
-        this.owner = null;
         owner.removeBookmarks(this);
     }
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
@@ -1,5 +1,6 @@
 package run.ward.mmz.domain.post;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.jetbrains.annotations.NotNull;
 import run.ward.mmz.domain.account.Account;
@@ -18,11 +19,13 @@ public class Bookmark extends Auditable {
     private Long id;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "ownerId")
     @NotNull
     private Account owner;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "recipeId")
     @NotNull
     private Recipe recipe;

--- a/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
@@ -38,18 +38,14 @@ public class Bookmark extends Auditable {
 
     public void setRecipe(@NotNull Recipe recipe){
         this.recipe = recipe;
-        recipe.getBookmarks().add(this);
+        recipe.addBookmarks(this);
     }
 
     public void setOwner(@NotNull Account owner){
         this.owner = owner;
-        owner.getBookmarks().add(this);
+        owner.addBookmarks(this);
     }
 
-    public void mappingBookmark(Recipe recipe, Account owner) {
-        this.recipe = recipe;
-        this.owner = owner;
-    }
 
 
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Bookmark.java
@@ -36,7 +36,28 @@ public class Bookmark extends Auditable {
         this.recipe = recipe;
     }
 
-    public void setRecipe(@NotNull Recipe recipe){
+
+    public void setBookmarked(Recipe recipe, Account account) {
+        this.setRecipe(recipe);
+        this.setOwner(account);
+    }
+
+    public void removeBookmarked(Recipe recipe, Account account) {
+        this.removeRecipe(recipe);
+        this.removeOwner(account);
+    }
+
+    protected void removeRecipe(@NotNull Recipe recipe){
+        this.recipe = null;
+        recipe.removeBookmarks(this);
+    }
+
+    public void removeOwner(@NotNull Account owner){
+        this.owner = null;
+        owner.removeBookmarks(this);
+    }
+
+    protected void setRecipe(@NotNull Recipe recipe){
         this.recipe = recipe;
         recipe.addBookmarks(this);
     }
@@ -45,6 +66,8 @@ public class Bookmark extends Auditable {
         this.owner = owner;
         owner.addBookmarks(this);
     }
+
+
 
 
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Direction.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Direction.java
@@ -1,8 +1,10 @@
 package run.ward.mmz.domain.post;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
 import run.ward.mmz.domain.file.Files;
+import run.ward.mmz.dto.request.patch.RecipePatchDto;
 
 
 import javax.persistence.*;
@@ -25,12 +27,13 @@ public class Direction {
     @NotBlank
     private String body;
 
+    @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "fileId")
-    @ToString.Exclude
     private Files files;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "recipeId")
     private Recipe recipe;
 
@@ -46,8 +49,10 @@ public class Direction {
             recipe.getDirections().add(this);
     }
 
+
+
     @Builder
-    public Direction(int index, String body, Files files, Recipe recipe) {
+    public Direction(Long id, int index, String body, Files files, Recipe recipe) {
         this.idx = index;
         this.body = body;
         this.files = files;

--- a/server/src/main/java/run/ward/mmz/domain/post/Ingredient.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Ingredient.java
@@ -1,5 +1,6 @@
 package run.ward.mmz.domain.post;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -31,6 +32,7 @@ public class Ingredient {
     private boolean isEssential;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "recipeId")
     private Recipe recipe;
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -1,11 +1,13 @@
 package run.ward.mmz.domain.post;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.auditable.Auditable;
 import run.ward.mmz.domain.file.Files;
+import run.ward.mmz.dto.request.patch.RecipePatchDto;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -33,6 +35,7 @@ public class Recipe extends Auditable {
     @NotBlank
     private String body;
 
+    @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "thumbnailId")
     private Files imgThumbNail;
@@ -51,26 +54,55 @@ public class Recipe extends Auditable {
     private String category;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "ownerId")
     private Account owner;
 
     @Column(nullable = false)
     private String level;
 
+    //orphanRemoval=true 영속성에서 관계가 끊어질 경우 commit 시점에서 삭제
+    @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Ingredient> ingredients = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Direction> directions = new ArrayList<>();
-
+    @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<RecipeTag> recipeTags = new ArrayList<>();
-
+    @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Review> reviews = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Bookmark> bookmarks = new ArrayList<>();
+
+    public void setBookmarks(List<Bookmark> bookmarks) {
+        this.bookmarks = bookmarks;
+    }
+
+    public void setReviews(List<Review> reviews) {
+        this.reviews = reviews;
+    }
+
+    public void setRecipeTags(List<RecipeTag> recipeTags) {
+        this.recipeTags = recipeTags;
+    }
+
+    public void setDirections(List<Direction> directions) {
+        this.directions = directions;
+    }
+
+    public void setIngredients(List<Ingredient> ingredients) {
+        this.ingredients = ingredients;
+    }
+
+    public void setImgThumbNail(Files imgThumbNail) {
+        this.imgThumbNail = imgThumbNail;
+    }
 
     // 연관관계 메서드
     public void setOwner(Account owner) {
@@ -87,6 +119,7 @@ public class Recipe extends Auditable {
             ingredients.add(ingredient);
         ingredient.setRecipe(this);
     }
+
 
     protected void addDirections(Direction direction) {
         if(!directions.contains(direction)) // directions가 list이므로 중복 허용, DB에는 중복되어있지 않지만, entity 객체에는 중복으로 들어가있음.
@@ -192,6 +225,7 @@ public class Recipe extends Auditable {
 
     }
 
+    @JsonIgnore
     public List<Tag> getTagList(){
 
         List<Tag> tagList = new ArrayList<>();
@@ -202,6 +236,10 @@ public class Recipe extends Auditable {
 
         return tagList;
     }
+
+//    public void deleteAllRecipeTag(){
+//        this.recipeTags = new ArrayList<>();
+//    }
 
 
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -110,8 +110,9 @@ public class Recipe extends Auditable {
 
         if(!reviews.contains(review)){
             reviews.add(review);
+            review.setRecipe(this);
         }
-        review.setRecipe(this);
+
     }
 
     protected void mappingRecipeTag(RecipeTag recipeTag){
@@ -131,8 +132,9 @@ public class Recipe extends Auditable {
         if(!bookmarks.contains(bookmark)) {
             bookmarks.add(bookmark);
             isBookmarked = true;
+            bookmark.setRecipe(this);
         }
-        bookmark.setRecipe(this);
+
 
 
     }

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -94,47 +94,44 @@ public class Recipe extends Auditable {
     }
 
     protected void addIngredients(Ingredient ingredient) {
-        if(!ingredients.contains(ingredient))  // ingredients가 list이므로 중복 허용, DB에는 중복되어있지 않지만, entity 객체에는 중복으로 들어가있음.
+        if (!ingredients.contains(ingredient))  // ingredients가 list이므로 중복 허용, DB에는 중복되어있지 않지만, entity 객체에는 중복으로 들어가있음.
             ingredients.add(ingredient);
         ingredient.setRecipe(this);
     }
 
 
     protected void addDirections(Direction direction) {
-        if(!directions.contains(direction)) // directions가 list이므로 중복 허용, DB에는 중복되어있지 않지만, entity 객체에는 중복으로 들어가있음.
+        if (!directions.contains(direction)) // directions가 list이므로 중복 허용, DB에는 중복되어있지 않지만, entity 객체에는 중복으로 들어가있음.
             directions.add(direction);
         direction.setRecipe(this);
     }
 
     protected void addReviews(Review review) {
 
-        if(!reviews.contains(review)){
+        if (!reviews.contains(review)) {
             reviews.add(review);
             review.setRecipe(this);
         }
 
     }
 
-    protected void mappingRecipeTag(RecipeTag recipeTag){
-        if(!recipeTags.contains(recipeTag))
+    protected void mappingRecipeTag(RecipeTag recipeTag) {
+        if (!recipeTags.contains(recipeTag))
             this.recipeTags.add(recipeTag);
     }
 
     public void removeBookmarks(Bookmark bookmark) {
-        if(bookmarks.contains(bookmark)) {
-            bookmarks.remove(bookmark);
-            isBookmarked = false;
-        }
+        bookmarks.remove(bookmark);
+        isBookmarked = false;
     }
 
     public void addBookmarks(Bookmark bookmark) {
 
-        if(!bookmarks.contains(bookmark)) {
+        if (!bookmarks.contains(bookmark)) {
             bookmarks.add(bookmark);
             isBookmarked = true;
             bookmark.setRecipe(this);
         }
-
 
 
     }
@@ -195,33 +192,33 @@ public class Recipe extends Auditable {
 
     /**
      * 비즈니스 로직
-     *
      */
 
-    public void addViews(){
-        if(views < 0){
+    public void addViews() {
+        if (views < 0) {
             //ToDo : views 는 0 보다 작은 값이 들어 갈 수 없음. -> Exception
         }
         this.views += 1;
     }
 
-    public void updateStars(){
+    public void updateStars() {
 
         double stars = 0;
 
-        for(Review review : reviews){
+        for (Review review : reviews) {
             stars += review.getStars();
         }
 
         this.stars = stars / reviews.size();
 
     }
+
     @JsonIgnore
-    public List<Tag> getTagList(){
+    public List<Tag> getTagList() {
 
         List<Tag> tagList = new ArrayList<>();
 
-        for(RecipeTag recipeTag : this.recipeTags) {
+        for (RecipeTag recipeTag : this.recipeTags) {
             tagList.add(recipeTag.getTag());
         }
 
@@ -229,18 +226,14 @@ public class Recipe extends Auditable {
     }
 
 
-
 //    public void deleteAllRecipeTag(){
 //        this.recipeTags = new ArrayList<>();
 //    }
 
 
-
-
     /**
      * 레시피 삭제
      */
-
 
 
 }

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -192,6 +192,17 @@ public class Recipe extends Auditable {
 
     }
 
+    public List<Tag> getTagList(){
+
+        List<Tag> tagList = new ArrayList<>();
+
+        for(RecipeTag recipeTag : this.recipeTags) {
+            tagList.add(recipeTag.getTag());
+        }
+
+        return tagList;
+    }
+
 
 
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -65,7 +65,6 @@ public class Recipe extends Auditable {
     @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Ingredient> ingredients = new ArrayList<>();
-
     @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Direction> directions = new ArrayList<>();
@@ -75,7 +74,6 @@ public class Recipe extends Auditable {
     @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Review> reviews = new ArrayList<>();
-
     @JsonIgnore
     @OneToMany(mappedBy = "recipe", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Bookmark> bookmarks = new ArrayList<>();
@@ -174,6 +172,7 @@ public class Recipe extends Auditable {
 
     // 레시피 생성 메서드
     @Builder
+    @JsonIgnore
     public static Recipe createRecipe(String title, String body, String category, Files imgThumbNail, Account owner, String level, List<Ingredient> ingredients, List<Direction> directions) {
 
         //Todo : 잘못된 값 혹은 null값이 들어올 경우 처리할 수 있는 Exception이 있어야한다.
@@ -224,7 +223,6 @@ public class Recipe extends Auditable {
         this.stars = stars / reviews.size();
 
     }
-
     @JsonIgnore
     public List<Tag> getTagList(){
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -82,25 +82,6 @@ public class Recipe extends Auditable {
         this.bookmarks = bookmarks;
     }
 
-    public void setReviews(List<Review> reviews) {
-        this.reviews = reviews;
-    }
-
-    public void setRecipeTags(List<RecipeTag> recipeTags) {
-        this.recipeTags = recipeTags;
-    }
-
-    public void setDirections(List<Direction> directions) {
-        this.directions = directions;
-    }
-
-    public void setIngredients(List<Ingredient> ingredients) {
-        this.ingredients = ingredients;
-    }
-
-    public void setImgThumbNail(Files imgThumbNail) {
-        this.imgThumbNail = imgThumbNail;
-    }
 
     // 연관관계 메서드
     public void setOwner(Account owner) {
@@ -126,7 +107,10 @@ public class Recipe extends Auditable {
     }
 
     protected void addReviews(Review review) {
-        reviews.add(review);
+
+        if(!reviews.contains(review)){
+            reviews.add(review);
+        }
         review.setRecipe(this);
     }
 
@@ -136,14 +120,21 @@ public class Recipe extends Auditable {
     }
 
     protected void removeBookmarks(Bookmark bookmark) {
-        bookmarks.remove(bookmark);
-        isBookmarked = false;
+        if(bookmarks.contains(bookmark)) {
+            bookmarks.remove(bookmark);
+            isBookmarked = false;
+        }
     }
 
     protected void addBookmarks(Bookmark bookmark) {
-        bookmarks.add(bookmark);
+
+        if(!bookmarks.contains(bookmark)) {
+            bookmarks.add(bookmark);
+            isBookmarked = true;
+        }
         bookmark.setRecipe(this);
-        isBookmarked = true;
+
+
     }
 
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Recipe.java
@@ -119,14 +119,14 @@ public class Recipe extends Auditable {
             this.recipeTags.add(recipeTag);
     }
 
-    protected void removeBookmarks(Bookmark bookmark) {
+    public void removeBookmarks(Bookmark bookmark) {
         if(bookmarks.contains(bookmark)) {
             bookmarks.remove(bookmark);
             isBookmarked = false;
         }
     }
 
-    protected void addBookmarks(Bookmark bookmark) {
+    public void addBookmarks(Bookmark bookmark) {
 
         if(!bookmarks.contains(bookmark)) {
             bookmarks.add(bookmark);
@@ -225,6 +225,8 @@ public class Recipe extends Auditable {
 
         return tagList;
     }
+
+
 
 //    public void deleteAllRecipeTag(){
 //        this.recipeTags = new ArrayList<>();

--- a/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
@@ -45,11 +45,4 @@ public class RecipeTag {
     }
 
 
-    public Recipe getRecipeByTag(Tag tag){
-        if(tag.getId().equals(this.tag.getId()))
-            return this.recipe;
-        else
-            return null;
-    }
-
 }

--- a/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
@@ -18,12 +18,12 @@ public class RecipeTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JsonIgnore
     @JoinColumn(name = "tagId")
     private Tag tag;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JsonIgnore
     @JoinColumn(name = "recipeId")
     private Recipe recipe;

--- a/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -43,12 +44,6 @@ public class RecipeTag {
         this.recipe = recipe;
     }
 
-    public Tag getTagByRecipe(Recipe recipe){
-        if(recipe.getId().equals(this.recipe.getId()))
-            return this.tag;
-        else
-            return null;
-    }
 
     public Recipe getRecipeByTag(Tag tag){
         if(tag.getId().equals(this.tag.getId()))

--- a/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/RecipeTag.java
@@ -1,10 +1,8 @@
 package run.ward.mmz.domain.post;
 
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -21,10 +19,12 @@ public class RecipeTag {
     private Long id;
 
     @ManyToOne(cascade = CascadeType.ALL)
+    @JsonIgnore
     @JoinColumn(name = "tagId")
     private Tag tag;
 
     @ManyToOne(cascade = CascadeType.ALL)
+    @JsonIgnore
     @JoinColumn(name = "recipeId")
     private Recipe recipe;
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Review.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Review.java
@@ -24,12 +24,12 @@ public class Review extends Auditable {
     private int stars;
 
     @JsonIgnore
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "ownerId")
     private Account owner;
 
     @JsonIgnore
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "recipeId")
     private Recipe recipe;
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Review.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Review.java
@@ -1,5 +1,6 @@
 package run.ward.mmz.domain.post;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.auditable.Auditable;
@@ -22,11 +23,13 @@ public class Review extends Auditable {
     @Column(columnDefinition = "integer default 0", nullable = false)
     private int stars;
 
-    @ManyToOne
+    @JsonIgnore
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "ownerId")
     private Account owner;
 
-    @ManyToOne
+    @JsonIgnore
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "recipeId")
     private Recipe recipe;
 

--- a/server/src/main/java/run/ward/mmz/domain/post/Review.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Review.java
@@ -36,12 +36,14 @@ public class Review extends Auditable {
     // 연관관계 메서드
     public void setOwner(Account owner) {
         this.owner = owner;
-        owner.getReviews().add(this);
+        if(owner.getReviews().contains(this))
+            owner.getReviews().add(this);
     }
 
     protected void setRecipe(Recipe recipe){
         this.recipe = recipe;
-        recipe.getReviews().add(this);
+        if(recipe.getReviews().contains(this))
+            recipe.getReviews().add(this);
     }
 
     @Builder

--- a/server/src/main/java/run/ward/mmz/domain/post/Tag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Tag.java
@@ -33,6 +33,18 @@ public class Tag {
     }
 
 
+    public List<Recipe> getRecipeList(){
+
+        List<Recipe> recipeList = new ArrayList<>();
+
+        for(RecipeTag recipeTag : this.recipeTags) {
+            recipeList.add(recipeTag.getRecipe());
+        }
+
+        return recipeList;
+    }
+
+
     @Builder
     public Tag(String name) {
         this.name = name;

--- a/server/src/main/java/run/ward/mmz/domain/post/Tag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Tag.java
@@ -1,9 +1,7 @@
 package run.ward.mmz.domain.post;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -23,6 +21,7 @@ public class Tag {
     private String name;
 
 
+    @JsonIgnore
     @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<RecipeTag> recipeTags = new ArrayList<>();
 
@@ -33,6 +32,7 @@ public class Tag {
     }
 
 
+    @JsonIgnore
     public List<Recipe> getRecipeList(){
 
         List<Recipe> recipeList = new ArrayList<>();

--- a/server/src/main/java/run/ward/mmz/domain/post/Tag.java
+++ b/server/src/main/java/run/ward/mmz/domain/post/Tag.java
@@ -31,7 +31,6 @@ public class Tag {
             this.recipeTags.add(recipeTag);
     }
 
-
     @JsonIgnore
     public List<Recipe> getRecipeList(){
 

--- a/server/src/main/java/run/ward/mmz/domain/subscribe/Subscribe.java
+++ b/server/src/main/java/run/ward/mmz/domain/subscribe/Subscribe.java
@@ -1,9 +1,6 @@
 package run.ward.mmz.domain.subscribe;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import run.ward.mmz.domain.account.Account;
 
 import javax.persistence.*;
@@ -21,10 +18,12 @@ public class Subscribe {
 
     @JoinColumn(name = "toUserId")
     @ManyToOne
+    @ToString.Exclude
     private Account toUser;
 
     @JoinColumn(name = "fromUserId")
     @ManyToOne
+    @ToString.Exclude
     private Account forUser;
 
 

--- a/server/src/main/java/run/ward/mmz/dto/common/FilesDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/common/FilesDto.java
@@ -1,11 +1,8 @@
 package run.ward.mmz.dto.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Getter
 @NoArgsConstructor
 public class FilesDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/DirectionPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/DirectionPatchDto.java
@@ -1,10 +1,11 @@
 package run.ward.mmz.dto.request.patch;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class DirectionPatchDto {
 
     private Long id;

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/DirectionPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/DirectionPatchDto.java
@@ -1,14 +1,13 @@
 package run.ward.mmz.dto.request.patch;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
-@Getter
+@Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
+
 public class DirectionPatchDto {
 
-    private Long id;
     private int index;
     private String imgDirectionUrl;
     private String body;

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/DirectionPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/DirectionPatchDto.java
@@ -1,0 +1,14 @@
+package run.ward.mmz.dto.request.patch;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DirectionPatchDto {
+
+    private Long id;
+    private int index;
+    private String imgDirectionUrl;
+    private String body;
+}

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/IngredientPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/IngredientPatchDto.java
@@ -1,11 +1,12 @@
 package run.ward.mmz.dto.request.patch;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class IngredientPatchDto {
 
     private Long id;

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/IngredientPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/IngredientPatchDto.java
@@ -3,13 +3,10 @@ package run.ward.mmz.dto.request.patch;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
-@Getter
+@Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class IngredientPatchDto {
 
-    private Long id;
     private int index;
     private String name;
     private String amount;

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/IngredientPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/IngredientPatchDto.java
@@ -1,0 +1,17 @@
+package run.ward.mmz.dto.request.patch;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class IngredientPatchDto {
+
+    private Long id;
+    private int index;
+    private String name;
+    private String amount;
+    @JsonProperty("isEssential")
+    private boolean isEssential;
+}

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/RecipePatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/RecipePatchDto.java
@@ -1,0 +1,24 @@
+package run.ward.mmz.dto.request.patch;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class RecipePatchDto {
+
+    private Long id;
+    private String title;
+    private String body;
+    private String category;
+    private String imgThumbNailUrl;
+    private String level;
+
+    private List<DirectionPatchDto> directions;
+    private List<IngredientPatchDto> ingredients;
+    private List<TagPatchDto> tags;
+
+}

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/RecipePatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/RecipePatchDto.java
@@ -5,10 +5,8 @@ import lombok.*;
 
 import java.util.List;
 
-@Getter
+@Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class RecipePatchDto {
 
     private String title;

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/RecipePatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/RecipePatchDto.java
@@ -1,16 +1,16 @@
 package run.ward.mmz.dto.request.patch;
 
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class RecipePatchDto {
 
-    private Long id;
     private String title;
     private String body;
     private String category;

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/TagPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/TagPatchDto.java
@@ -1,10 +1,11 @@
 package run.ward.mmz.dto.request.patch;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class TagPatchDto {
     String name;
 }

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/TagPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/TagPatchDto.java
@@ -1,0 +1,10 @@
+package run.ward.mmz.dto.request.patch;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TagPatchDto {
+    String name;
+}

--- a/server/src/main/java/run/ward/mmz/dto/request/patch/TagPatchDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/patch/TagPatchDto.java
@@ -2,10 +2,8 @@ package run.ward.mmz.dto.request.patch;
 
 import lombok.*;
 
-@Getter
+@Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class TagPatchDto {
     String name;
 }

--- a/server/src/main/java/run/ward/mmz/dto/request/post/DirectionPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/DirectionPostDto.java
@@ -1,15 +1,15 @@
 package run.ward.mmz.dto.request.post;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
 import run.ward.mmz.domain.file.Files;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class DirectionPostDto {
 
     private int index;

--- a/server/src/main/java/run/ward/mmz/dto/request/post/DirectionPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/DirectionPostDto.java
@@ -1,5 +1,6 @@
-package run.ward.mmz.dto.request;
+package run.ward.mmz.dto.request.post;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import run.ward.mmz.domain.file.Files;
@@ -8,6 +9,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 
 @Data
+@Builder
 public class DirectionPostDto {
 
     private int index;

--- a/server/src/main/java/run/ward/mmz/dto/request/post/IngredientPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/IngredientPostDto.java
@@ -6,8 +6,10 @@ import lombok.*;
 import java.io.Serializable;
 
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class IngredientPostDto{
 
     private int index;

--- a/server/src/main/java/run/ward/mmz/dto/request/post/IngredientPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/IngredientPostDto.java
@@ -1,16 +1,13 @@
-package run.ward.mmz.dto.request;
+package run.ward.mmz.dto.request.post;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 
 
-@Getter
-@NoArgsConstructor
+@Data
+@Builder
 public class IngredientPostDto{
 
     private int index;

--- a/server/src/main/java/run/ward/mmz/dto/request/post/RecipePostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/RecipePostDto.java
@@ -1,13 +1,14 @@
 package run.ward.mmz.dto.request.post;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class RecipePostDto{
 
 

--- a/server/src/main/java/run/ward/mmz/dto/request/post/RecipePostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/RecipePostDto.java
@@ -1,13 +1,13 @@
-package run.ward.mmz.dto.request;
+package run.ward.mmz.dto.request.post;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
 
 import java.util.List;
 
 
-@Getter
-@NoArgsConstructor
+@Data
+@Builder
 public class RecipePostDto{
 
 

--- a/server/src/main/java/run/ward/mmz/dto/request/post/ReviewPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/ReviewPostDto.java
@@ -1,4 +1,4 @@
-package run.ward.mmz.dto.request;
+package run.ward.mmz.dto.request.post;
 
 import lombok.Builder;
 import lombok.Data;

--- a/server/src/main/java/run/ward/mmz/dto/request/post/ReviewPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/ReviewPostDto.java
@@ -1,12 +1,13 @@
 package run.ward.mmz.dto.request.post;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import javax.persistence.Lob;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ReviewPostDto {
 
     private String body;

--- a/server/src/main/java/run/ward/mmz/dto/request/post/TagPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/TagPostDto.java
@@ -1,12 +1,12 @@
 package run.ward.mmz.dto.request.post;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
-@Data
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class TagPostDto {
-
     private String name;
 }

--- a/server/src/main/java/run/ward/mmz/dto/request/post/TagPostDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/request/post/TagPostDto.java
@@ -1,4 +1,4 @@
-package run.ward.mmz.dto.request;
+package run.ward.mmz.dto.request.post;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/server/src/main/java/run/ward/mmz/dto/respones/AccountInfoDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/AccountInfoDto.java
@@ -1,0 +1,14 @@
+package run.ward.mmz.dto.respones;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AccountInfoDto {
+
+    private Long id;
+    private String name;
+    private String bio;
+    private String imgProfileUrl;
+}

--- a/server/src/main/java/run/ward/mmz/dto/respones/DirectionResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/DirectionResponseDto.java
@@ -2,9 +2,9 @@ package run.ward.mmz.dto.respones;
 
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
 public class DirectionResponseDto {
     private int index;

--- a/server/src/main/java/run/ward/mmz/dto/respones/DirectionResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/DirectionResponseDto.java
@@ -2,9 +2,10 @@ package run.ward.mmz.dto.respones;
 
 
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
-@Getter
+@Data
 @Builder
 public class DirectionResponseDto {
     private int index;

--- a/server/src/main/java/run/ward/mmz/dto/respones/IngredientResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/IngredientResponseDto.java
@@ -1,9 +1,10 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
-@Getter
+@Data
 @Builder
 public class IngredientResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/IngredientResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/IngredientResponseDto.java
@@ -1,10 +1,9 @@
 package run.ward.mmz.dto.respones;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
 public class IngredientResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeInfoDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeInfoDto.java
@@ -14,6 +14,7 @@ public class RecipeInfoDto {
     private String title;
     private String imgThumbNailUrl;
     private String stars;
+    private int views;
     private List<TagResponseDto> tags;
 
 }

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeInfoDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeInfoDto.java
@@ -1,11 +1,11 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
+@Getter
 @Builder
 public class RecipeInfoDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeInfoDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeInfoDto.java
@@ -1,11 +1,12 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
 import java.util.List;
 
-@Getter
+@Data
 @Builder
 public class RecipeInfoDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
@@ -1,14 +1,15 @@
 package run.ward.mmz.dto.respones;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
 import java.util.List;
 
-@Getter
+@Data
 @Builder
 public class RecipeResponseDto {
-
     private Long id;
     private String title;
     private String body;
@@ -20,7 +21,6 @@ public class RecipeResponseDto {
     private int views;
     private String createDate;
     private String modifyDate;
-
     private List<DirectionResponseDto> directions;
     private List<IngredientResponseDto> ingredients;
     private List<TagResponseDto> tags;

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
@@ -11,6 +11,7 @@ public class RecipeResponseDto {
 
     private Long id;
     private String title;
+    private String body;
     private String category;
     private String imgThumbNailUrl;
     private String level;

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
@@ -1,11 +1,11 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
-@Data
+@Getter
 @Builder
 public class RecipeResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/RecipeResponseDto.java
@@ -10,6 +10,8 @@ import java.util.List;
 @Data
 @Builder
 public class RecipeResponseDto {
+
+    private AccountInfoDto owner;
     private Long id;
     private String title;
     private String body;

--- a/server/src/main/java/run/ward/mmz/dto/respones/ReviewResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/ReviewResponseDto.java
@@ -2,9 +2,10 @@ package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
 
+import lombok.Data;
 import lombok.Getter;
 
-@Getter
+@Data
 @Builder
 public class ReviewResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/ReviewResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/ReviewResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 public class ReviewResponseDto {
 
+    private AccountInfoDto owner;
     private Long id;
     private String body;
     private int stars;

--- a/server/src/main/java/run/ward/mmz/dto/respones/ReviewResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/ReviewResponseDto.java
@@ -1,9 +1,10 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
-import lombok.Data;
 
-@Data
+import lombok.Getter;
+
+@Getter
 @Builder
 public class ReviewResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/TagResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/TagResponseDto.java
@@ -1,9 +1,9 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
 public class TagResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/dto/respones/TagResponseDto.java
+++ b/server/src/main/java/run/ward/mmz/dto/respones/TagResponseDto.java
@@ -1,9 +1,10 @@
 package run.ward.mmz.dto.respones;
 
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
-@Getter
+@Data
 @Builder
 public class TagResponseDto {
 

--- a/server/src/main/java/run/ward/mmz/handler/exception/CustomException.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/CustomException.java
@@ -1,0 +1,17 @@
+package run.ward.mmz.handler.exception;
+
+import lombok.Getter;
+
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private static final long serialVersionUID = 15495845L;
+
+    private final ExceptionCode exceptionCode;
+
+    public CustomException(ExceptionCode code) {
+        super(code.getMessage());
+        this.exceptionCode = code;
+    }
+}

--- a/server/src/main/java/run/ward/mmz/handler/exception/ErrorResponse.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/ErrorResponse.java
@@ -49,9 +49,9 @@ public class ErrorResponse {
 
     @Getter
     public static class FieldError {
-        private final String field;
-        private final Object rejectedValue;
-        private final String reason;
+        private String field;
+        private Object rejectedValue;
+        private String reason;
 
         private FieldError(String field, Object rejectedValue, String reason) {
             this.field = field;
@@ -74,9 +74,9 @@ public class ErrorResponse {
 
     @Getter
     public static class ConstraintViolationError {
-        private final String propertyPath;
-        private final Object rejectedValue;
-        private final String reason;
+        private String propertyPath;
+        private Object rejectedValue;
+        private String reason;
 
         private ConstraintViolationError(String propertyPath, Object rejectedValue,
                                          String reason) {

--- a/server/src/main/java/run/ward/mmz/handler/exception/ErrorResponse.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/ErrorResponse.java
@@ -1,0 +1,98 @@
+package run.ward.mmz.handler.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import javax.validation.ConstraintViolation;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+    private int status;
+    private String message;
+    private List<FieldError> fieldErrors;
+    private List<ConstraintViolationError> violationErrors;
+
+    private ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    private ErrorResponse(final List<FieldError> fieldErrors,
+                          final List<ConstraintViolationError> violationErrors) {
+        this.fieldErrors = fieldErrors;
+        this.violationErrors = violationErrors;
+    }
+
+    public static ErrorResponse of(BindingResult bindingResult) {
+        return new ErrorResponse(FieldError.of(bindingResult), null);
+    }
+
+    public static ErrorResponse of(Set<ConstraintViolation<?>> violations) {
+        return new ErrorResponse(null, ConstraintViolationError.of(violations));
+    }
+
+    public static ErrorResponse of(ExceptionCode exceptionCode) {
+        return new ErrorResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus) {
+        return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return new ErrorResponse(httpStatus.value(), message);
+    }
+
+    @Getter
+    public static class FieldError {
+        private final String field;
+        private final Object rejectedValue;
+        private final String reason;
+
+        private FieldError(String field, Object rejectedValue, String reason) {
+            this.field = field;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors =
+                    bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ?
+                                    "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    public static class ConstraintViolationError {
+        private final String propertyPath;
+        private final Object rejectedValue;
+        private final String reason;
+
+        private ConstraintViolationError(String propertyPath, Object rejectedValue,
+                                         String reason) {
+            this.propertyPath = propertyPath;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<ConstraintViolationError> of(
+                Set<ConstraintViolation<?>> constraintViolations) {
+            return constraintViolations.stream()
+                    .map(constraintViolation -> new ConstraintViolationError(
+                            constraintViolation.getPropertyPath().toString(),
+                            constraintViolation.getInvalidValue().toString(),
+                            constraintViolation.getMessage()
+                    )).collect(Collectors.toList());
+        }
+    }
+}

--- a/server/src/main/java/run/ward/mmz/handler/exception/ExceptionCode.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/ExceptionCode.java
@@ -1,0 +1,36 @@
+package run.ward.mmz.handler.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+    USER_ACCESS_DENIED(403,"Access Denied User."),
+    USER_NOT_FOUND(404, "User not found."),
+    USER_EXISTS(409, "User exists."),
+    RECIPE_NOT_FOUND(404, "Recipe not found."),
+    RECIPE_EXISTS(409, "Recipe exists."),
+
+    INGREDIENT_NOT_FOUND(404, "Ingredient not found."),
+    INGREDIENT_EXISTS(409, "Ingredient exists."),
+
+    DIRECTION_NOT_FOUND(404, "Direction not found."),
+    DIRECTION_EXISTS(409, "Direction exists."),
+
+    REVIEW_NOT_FOUND(404, "Review not found."),
+    REVIEW_EXISTS(409, "Review exists."),
+
+    TAG_NOT_FOUND(404, "Tag not found."),
+    TAG_EXISTS(409, "Tag exists."),
+
+    FILE_NOT_FOUND(404, "File not found."),
+    FILE_UPLOAD_FAILED(417, "File upload fail."),
+    FILE_SIZE_EXCEED(431,"File size exceed."),
+    FILE_EXTENSION_INVALID(431,"File extension invalid.");
+
+    private final int status;
+    private final String message;
+
+}

--- a/server/src/main/java/run/ward/mmz/handler/exception/ExceptionCode.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/ExceptionCode.java
@@ -22,6 +22,9 @@ public enum ExceptionCode {
     REVIEW_NOT_FOUND(404, "Review not found."),
     REVIEW_EXISTS(409, "Review exists."),
 
+    BOOKMARK_NOT_FOUND(404, "Bookmark not found."),
+    BOOKMARK_EXISTS(409, "Bookmark exists."),
+
     TAG_NOT_FOUND(404, "Tag not found."),
     TAG_EXISTS(409, "Tag exists."),
 

--- a/server/src/main/java/run/ward/mmz/handler/exception/ExceptionHandler.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/ExceptionHandler.java
@@ -1,8 +1,0 @@
-package run.ward.mmz.handler.exception;
-
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-@RestControllerAdvice
-public class ExceptionHandler {
-
-}

--- a/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package run.ward.mmz.handler.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.lang.reflect.UndeclaredThrowableException;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UndeclaredThrowableException.class)
+    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e){
+
+        log.info(e.getCause().toString());
+        log.info(e.getUndeclaredThrowable().toString());
+        log.info(e.getStackTrace().toString());
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+}

--- a/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
@@ -2,8 +2,13 @@ package run.ward.mmz.handler.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.lang.reflect.UndeclaredThrowableException;
 
@@ -12,13 +17,59 @@ import java.lang.reflect.UndeclaredThrowableException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customException(CustomException e) {
+        final ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
+
+        return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getStatus()));
+    }
+
     @ExceptionHandler(UndeclaredThrowableException.class)
-    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e){
+    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e) {
 
         log.info(e.getCause().toString());
-        log.info(e.getUndeclaredThrowable().toString());
-        log.info(e.getStackTrace().toString());
 
         return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
     }
+
+
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ErrorResponse httpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+
+        log.info(e.getCause().toString());
+
+        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ErrorResponse missingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+
+        log.info(e.getCause().toString());
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ErrorResponse globalException(Exception e) {
+
+        log.error("Exception : ", e);
+
+        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+
+        log.error("Exception : ", e);
+
+        return new ResponseEntity<>(ErrorResponse.of(ExceptionCode.FILE_SIZE_EXCEED), HttpStatus.BAD_REQUEST);
+    }
+
+
 }

--- a/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
@@ -16,60 +16,62 @@ import java.lang.reflect.UndeclaredThrowableException;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<?> customException(CustomException e) {
-        final ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
-
-        return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getStatus()));
-    }
-
-    @ExceptionHandler(UndeclaredThrowableException.class)
-    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e) {
-
-        log.info(e.getCause().toString());
-
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
-    }
-
-
-    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ErrorResponse httpRequestMethodNotSupportedException(
-            HttpRequestMethodNotSupportedException e) {
-
-        log.info(e.getCause().toString());
-
-        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
-    }
-
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ErrorResponse missingServletRequestParameterException(
-            MissingServletRequestParameterException e) {
-
-        log.info(e.getCause().toString());
-
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
-    }
-
-
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(Exception.class)
-    public ErrorResponse globalException(Exception e) {
-
-        log.error("Exception : ", e);
-
-        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
-
-        log.error("Exception : ", e);
-
-        return new ResponseEntity<>(ErrorResponse.of(ExceptionCode.FILE_SIZE_EXCEED), HttpStatus.BAD_REQUEST);
-    }
+//
+//    @ExceptionHandler(CustomException.class)
+//    public ResponseEntity<?> customException(CustomException e) {
+//        ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
+//
+//        return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getStatus()));
+//    }
+//
+//    @ExceptionHandler(UndeclaredThrowableException.class)
+//    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e) {
+//
+//        log.info(e.getCause().toString());
+//
+//        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+//    }
+//
+//
+//    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+//    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+//    public ErrorResponse httpRequestMethodNotSupportedException(
+//            HttpRequestMethodNotSupportedException e) {
+//
+//        log.info(e.getCause().toString());
+//
+//        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+//    }
+//
+//    @ResponseStatus(HttpStatus.BAD_REQUEST)
+//    @ExceptionHandler(MissingServletRequestParameterException.class)
+//    public ErrorResponse missingServletRequestParameterException(
+//            MissingServletRequestParameterException e) {
+//
+//        log.info(e.getCause().toString());
+//
+//        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+//    }
+//
+//
+//    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+//    @ExceptionHandler(Exception.class)
+//    public ErrorResponse globalException(Exception e) {
+//
+//        log.error("Exception : ", e);
+//        e.printStackTrace();
+//        System.out.println("e.getCause() = " + e.getCause());
+//
+//        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+//    }
+//
+//    @ExceptionHandler(MaxUploadSizeExceededException.class)
+//    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+//
+//        log.error("Exception : ", e);
+//
+//        return new ResponseEntity<>(ErrorResponse.of(ExceptionCode.FILE_SIZE_EXCEED), HttpStatus.BAD_REQUEST);
+//    }
 
 
 }

--- a/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/run/ward/mmz/handler/exception/GlobalExceptionHandler.java
@@ -16,62 +16,62 @@ import java.lang.reflect.UndeclaredThrowableException;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-//
-//    @ExceptionHandler(CustomException.class)
-//    public ResponseEntity<?> customException(CustomException e) {
-//        ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
-//
-//        return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getStatus()));
-//    }
-//
-//    @ExceptionHandler(UndeclaredThrowableException.class)
-//    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e) {
-//
-//        log.info(e.getCause().toString());
-//
-//        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
-//    }
-//
-//
-//    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-//    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-//    public ErrorResponse httpRequestMethodNotSupportedException(
-//            HttpRequestMethodNotSupportedException e) {
-//
-//        log.info(e.getCause().toString());
-//
-//        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
-//    }
-//
-//    @ResponseStatus(HttpStatus.BAD_REQUEST)
-//    @ExceptionHandler(MissingServletRequestParameterException.class)
-//    public ErrorResponse missingServletRequestParameterException(
-//            MissingServletRequestParameterException e) {
-//
-//        log.info(e.getCause().toString());
-//
-//        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
-//    }
-//
-//
-//    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-//    @ExceptionHandler(Exception.class)
-//    public ErrorResponse globalException(Exception e) {
-//
-//        log.error("Exception : ", e);
-//        e.printStackTrace();
-//        System.out.println("e.getCause() = " + e.getCause());
-//
-//        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
-//    }
-//
-//    @ExceptionHandler(MaxUploadSizeExceededException.class)
-//    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
-//
-//        log.error("Exception : ", e);
-//
-//        return new ResponseEntity<>(ErrorResponse.of(ExceptionCode.FILE_SIZE_EXCEED), HttpStatus.BAD_REQUEST);
-//    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customException(CustomException e) {
+        ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
+
+        return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getStatus()));
+    }
+
+    @ExceptionHandler(UndeclaredThrowableException.class)
+    public ErrorResponse undeclaredThrowableException(UndeclaredThrowableException e) {
+
+        log.info(e.getCause().toString());
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ErrorResponse httpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+
+        log.info(e.getCause().toString());
+
+        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ErrorResponse missingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+
+        log.info(e.getCause().toString());
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ErrorResponse globalException(Exception e) {
+
+        log.error("Exception : ", e);
+        e.printStackTrace();
+        System.out.println("e.getCause() = " + e.getCause());
+
+        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+
+        log.error("Exception : ", e);
+
+        return new ResponseEntity<>(ErrorResponse.of(ExceptionCode.FILE_SIZE_EXCEED), HttpStatus.BAD_REQUEST);
+    }
 
 
 }

--- a/server/src/main/java/run/ward/mmz/handler/file/FileHandler.java
+++ b/server/src/main/java/run/ward/mmz/handler/file/FileHandler.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 import run.ward.mmz.dto.common.FilesDto;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,8 +32,10 @@ public class FileHandler {
             String contentType = file.getContentType();
             String originalFilename = file.getOriginalFilename();
 
-            if (ObjectUtils.isEmpty(contentType) || ObjectUtils.isEmpty(originalFilename))
-                break;
+            if (ObjectUtils.isEmpty(contentType) || ObjectUtils.isEmpty(originalFilename)){
+                throw new CustomException(ExceptionCode.FILE_UPLOAD_FAILED);
+            }
+
 
             String ext = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
 
@@ -55,8 +59,11 @@ public class FileHandler {
                     filesDtoList.add(filesDto);
 
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    throw new CustomException(ExceptionCode.FILE_UPLOAD_FAILED);
                 }
+            }
+            else{
+                throw new CustomException(ExceptionCode.FILE_EXTENSION_INVALID);
             }
 
         }
@@ -72,7 +79,7 @@ public class FileHandler {
         String originalFilename = file.getOriginalFilename();
 
         if (ObjectUtils.isEmpty(contentType) || ObjectUtils.isEmpty(originalFilename)) {
-            return null;
+            throw new CustomException(ExceptionCode.FILE_UPLOAD_FAILED);
         }
 
         String ext = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
@@ -98,8 +105,11 @@ public class FileHandler {
                         .build();
 
             } catch (Exception e) {
-                e.printStackTrace();
+                throw new CustomException(ExceptionCode.FILE_UPLOAD_FAILED);
             }
+        }
+        else{
+            throw new CustomException(ExceptionCode.FILE_EXTENSION_INVALID);
         }
 
         return filesDto;

--- a/server/src/main/java/run/ward/mmz/log/LogType.java
+++ b/server/src/main/java/run/ward/mmz/log/LogType.java
@@ -10,6 +10,7 @@ public enum LogType {
 
     CONTROLLER("CONTROLLER"),
     SERVICE("SERVICE"),
+    MAPPER("MAPPER"),
     DATABASE("DATABASE");
 
     private final String type;

--- a/server/src/main/java/run/ward/mmz/mapper/account/AccountMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/account/AccountMapper.java
@@ -1,0 +1,10 @@
+package run.ward.mmz.mapper.account;
+
+import run.ward.mmz.domain.account.Account;
+import run.ward.mmz.dto.respones.AccountInfoDto;
+
+public interface AccountMapper {
+
+    AccountInfoDto toInfoDto(Account account);
+
+}

--- a/server/src/main/java/run/ward/mmz/mapper/account/AccountMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/account/AccountMapperImpl.java
@@ -1,0 +1,24 @@
+package run.ward.mmz.mapper.account;
+
+import org.springframework.stereotype.Component;
+import run.ward.mmz.domain.account.Account;
+import run.ward.mmz.dto.respones.AccountInfoDto;
+
+@Component
+public class AccountMapperImpl implements AccountMapper{
+
+    @Override
+    public AccountInfoDto toInfoDto(Account account) {
+
+        if (account == null) {
+            return null;
+        }
+
+        return AccountInfoDto.builder()
+                .id(account.getId())
+                .name(account.getName())
+                .imgProfileUrl(account.getImgProfile().getFileName())
+                .bio(account.getBio())
+                .build();
+    }
+}

--- a/server/src/main/java/run/ward/mmz/mapper/account/AccountMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/account/AccountMapperImpl.java
@@ -17,7 +17,7 @@ public class AccountMapperImpl implements AccountMapper{
         return AccountInfoDto.builder()
                 .id(account.getId())
                 .name(account.getName())
-                .imgProfileUrl(account.getImgProfile().getFileName())
+//                .imgProfileUrl(account.getImgProfile().getFileName())
                 .bio(account.getBio())
                 .build();
     }

--- a/server/src/main/java/run/ward/mmz/mapper/post/DirectionMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/DirectionMapper.java
@@ -11,8 +11,7 @@ import java.util.List;
 
 public interface DirectionMapper{
     Direction toEntity(DirectionPostDto dto, Files img);
-    List<Direction> toEntity(List<DirectionPostDto> dtos, List<Files> imgs);
-
+    List<Direction> toEntity(List<DirectionPostDto> dtoList, List<Files> imgList);
     DirectionPatchDto toPatchDto(Direction direction);
     List<DirectionPatchDto> toPatchDto(List<Direction> directionList);
 

--- a/server/src/main/java/run/ward/mmz/mapper/post/DirectionMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/DirectionMapper.java
@@ -3,7 +3,8 @@ package run.ward.mmz.mapper.post;
 
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.Direction;
-import run.ward.mmz.dto.request.DirectionPostDto;
+import run.ward.mmz.dto.request.patch.DirectionPatchDto;
+import run.ward.mmz.dto.request.post.DirectionPostDto;
 import run.ward.mmz.dto.respones.DirectionResponseDto;
 
 import java.util.List;
@@ -11,6 +12,9 @@ import java.util.List;
 public interface DirectionMapper{
     Direction toEntity(DirectionPostDto dto, Files img);
     List<Direction> toEntity(List<DirectionPostDto> dtos, List<Files> imgs);
+
+    DirectionPatchDto toPatchDto(Direction direction);
+    List<DirectionPatchDto> toPatchDto(List<Direction> directionList);
 
     DirectionResponseDto toResponseDto(Direction direction);
     List<DirectionResponseDto> toResponseDto(List<Direction> directionList);

--- a/server/src/main/java/run/ward/mmz/mapper/post/IngredientMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/IngredientMapper.java
@@ -9,6 +9,7 @@ import run.ward.mmz.mapper.post.common.RecipeElementMapper;
 import java.util.List;
 
 public interface IngredientMapper extends RecipeElementMapper<Ingredient, IngredientPostDto, IngredientResponseDto> {
+
     IngredientPatchDto toPatchDto(Ingredient ingredient);
     List<IngredientPatchDto> toPatchDto(List<Ingredient> ingredientList);
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/IngredientMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/IngredientMapper.java
@@ -1,10 +1,14 @@
 package run.ward.mmz.mapper.post;
 
 import run.ward.mmz.domain.post.Ingredient;
-import run.ward.mmz.dto.request.IngredientPostDto;
+import run.ward.mmz.dto.request.patch.IngredientPatchDto;
+import run.ward.mmz.dto.request.post.IngredientPostDto;
 import run.ward.mmz.dto.respones.IngredientResponseDto;
 import run.ward.mmz.mapper.post.common.RecipeElementMapper;
 
-public interface IngredientMapper extends RecipeElementMapper<Ingredient, IngredientPostDto, IngredientResponseDto> {
+import java.util.List;
 
+public interface IngredientMapper extends RecipeElementMapper<Ingredient, IngredientPostDto, IngredientResponseDto> {
+    IngredientPatchDto toPatchDto(Ingredient ingredient);
+    List<IngredientPatchDto> toPatchDto(List<Ingredient> ingredientList);
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/RecipeMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/RecipeMapper.java
@@ -4,7 +4,7 @@ package run.ward.mmz.mapper.post;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.*;
-import run.ward.mmz.dto.request.RecipePostDto;
+import run.ward.mmz.dto.request.post.RecipePostDto;
 import run.ward.mmz.dto.respones.RecipeInfoDto;
 import run.ward.mmz.dto.respones.RecipeResponseDto;
 
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface RecipeMapper {
     Recipe toEntity(Account owner, RecipePostDto recipePostDto, Files imgThumbNail, List<Ingredient> ingredients, List<Direction> directionList);
-    RecipeResponseDto toResponseDto(Recipe recipe, List<Tag> tagList);
-    RecipeInfoDto toInfoDto(Recipe recipe, List<Tag> tagList);
+    RecipeResponseDto toResponseDto(Recipe recipe);
+    RecipeInfoDto toInfoDto(Recipe recipe);
 
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/RecipeMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/RecipeMapper.java
@@ -4,6 +4,7 @@ package run.ward.mmz.mapper.post;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.*;
+import run.ward.mmz.dto.request.patch.RecipePatchDto;
 import run.ward.mmz.dto.request.post.RecipePostDto;
 import run.ward.mmz.dto.respones.RecipeInfoDto;
 import run.ward.mmz.dto.respones.RecipeResponseDto;
@@ -14,5 +15,6 @@ public interface RecipeMapper {
     Recipe toEntity(Account owner, RecipePostDto recipePostDto, Files imgThumbNail, List<Ingredient> ingredients, List<Direction> directionList);
     RecipeResponseDto toResponseDto(Recipe recipe);
     RecipeInfoDto toInfoDto(Recipe recipe);
+    RecipePatchDto toPatchDto(Recipe recipe);
 
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/ReviewMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/ReviewMapper.java
@@ -3,7 +3,7 @@ package run.ward.mmz.mapper.post;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
-import run.ward.mmz.dto.request.ReviewPostDto;
+import run.ward.mmz.dto.request.post.ReviewPostDto;
 import run.ward.mmz.dto.respones.ReviewResponseDto;
 
 import java.util.List;

--- a/server/src/main/java/run/ward/mmz/mapper/post/TagMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/TagMapper.java
@@ -2,11 +2,15 @@ package run.ward.mmz.mapper.post;
 
 import run.ward.mmz.domain.post.Tag;
 
-import run.ward.mmz.dto.request.TagPostDto;
+import run.ward.mmz.dto.request.patch.TagPatchDto;
+import run.ward.mmz.dto.request.post.TagPostDto;
 import run.ward.mmz.dto.respones.TagResponseDto;
 import run.ward.mmz.mapper.post.common.RecipeElementMapper;
 
+import java.util.List;
+
 
 public interface TagMapper extends RecipeElementMapper<Tag, TagPostDto, TagResponseDto> {
-
+    TagPatchDto toPatchDto(Tag tag);
+    List<TagPatchDto> toPatchDto(List<Tag> tagList);
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/common/RecipeElementMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/common/RecipeElementMapper.java
@@ -6,7 +6,6 @@ public interface RecipeElementMapper<E, Q, R> {
 
     E toEntity(Q q);
     List<E> toEntity(List<Q> qs);
-
     R toResponseDto(E e);
     List<R> toResponseDto(List<E> es);
 

--- a/server/src/main/java/run/ward/mmz/mapper/post/common/RecipeElementMapper.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/common/RecipeElementMapper.java
@@ -6,6 +6,8 @@ public interface RecipeElementMapper<E, Q, R> {
 
     E toEntity(Q q);
     List<E> toEntity(List<Q> qs);
+
+
     R toResponseDto(E e);
     List<R> toResponseDto(List<E> es);
 

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/DirectionMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/DirectionMapperImpl.java
@@ -3,7 +3,8 @@ package run.ward.mmz.mapper.post.impl;
 import org.springframework.stereotype.Component;
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.Direction;
-import run.ward.mmz.dto.request.DirectionPostDto;
+import run.ward.mmz.dto.request.patch.DirectionPatchDto;
+import run.ward.mmz.dto.request.post.DirectionPostDto;
 import run.ward.mmz.dto.respones.DirectionResponseDto;
 import run.ward.mmz.mapper.post.DirectionMapper;
 
@@ -17,7 +18,7 @@ public class DirectionMapperImpl implements DirectionMapper {
     @Override
     public Direction toEntity(DirectionPostDto directionPostDto, Files img) {
 
-        if(directionPostDto == null)
+        if (directionPostDto == null)
             return null;
 
         if (img == null)
@@ -33,21 +34,52 @@ public class DirectionMapperImpl implements DirectionMapper {
     @Override
     public List<Direction> toEntity(List<DirectionPostDto> directionPostDtos, List<Files> imgs) {
 
-        if(directionPostDtos.isEmpty())
+        if (directionPostDtos.isEmpty())
             return new ArrayList<>();
 
-        if(imgs.isEmpty())
+        if (imgs.isEmpty())
             return new ArrayList<>();
 
         List<Direction> directions = new ArrayList<>();
 
         int idx = 0;
 
-        for(DirectionPostDto directionPostDto : directionPostDtos){
+        for (DirectionPostDto directionPostDto : directionPostDtos) {
             directions.add(toEntity(directionPostDto, imgs.get(idx++)));
         }
 
         return directions;
+    }
+
+    @Override
+    public DirectionPatchDto toPatchDto(Direction direction) {
+
+        if (direction == null) {
+            return null;
+        }
+
+        return DirectionPatchDto.builder()
+                .id(direction.getId())
+                .imgDirectionUrl(direction.getFiles().getFileName())
+                .index(direction.getIdx())
+                .body(direction.getBody())
+                .build();
+    }
+
+    @Override
+    public List<DirectionPatchDto> toPatchDto(List<Direction> directionList) {
+
+        if(directionList.isEmpty()){
+            return new ArrayList<>();
+        }
+
+        List<DirectionPatchDto> directionPatchDtoList = new ArrayList<>();
+
+        for(Direction direction : directionList){
+            directionPatchDtoList.add(toPatchDto(direction));
+        }
+
+        return directionPatchDtoList;
     }
 
     @Override
@@ -68,13 +100,13 @@ public class DirectionMapperImpl implements DirectionMapper {
     @Override
     public List<DirectionResponseDto> toResponseDto(List<Direction> directionList) {
 
-        if(directionList.isEmpty()){
+        if (directionList.isEmpty()) {
             return new ArrayList<>();
         }
 
         List<DirectionResponseDto> directionResponseDtoList = new ArrayList<>();
 
-        for(Direction direction : directionList){
+        for (Direction direction : directionList) {
             directionResponseDtoList.add(toResponseDto(direction));
         }
 

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/DirectionMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/DirectionMapperImpl.java
@@ -51,6 +51,7 @@ public class DirectionMapperImpl implements DirectionMapper {
         return directions;
     }
 
+
     @Override
     public DirectionPatchDto toPatchDto(Direction direction) {
 

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/DirectionMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/DirectionMapperImpl.java
@@ -60,7 +60,6 @@ public class DirectionMapperImpl implements DirectionMapper {
         }
 
         return DirectionPatchDto.builder()
-                .id(direction.getId())
                 .imgDirectionUrl(direction.getFiles().getFileName())
                 .index(direction.getIdx())
                 .body(direction.getBody())

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/IngredientMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/IngredientMapperImpl.java
@@ -2,7 +2,8 @@ package run.ward.mmz.mapper.post.impl;
 
 import org.springframework.stereotype.Component;
 import run.ward.mmz.domain.post.Ingredient;
-import run.ward.mmz.dto.request.IngredientPostDto;
+import run.ward.mmz.dto.request.patch.IngredientPatchDto;
+import run.ward.mmz.dto.request.post.IngredientPostDto;
 import run.ward.mmz.dto.respones.IngredientResponseDto;
 import run.ward.mmz.mapper.post.IngredientMapper;
 
@@ -42,6 +43,38 @@ public class IngredientMapperImpl implements IngredientMapper {
         }
 
         return ingredients;
+    }
+
+    @Override
+    public IngredientPatchDto toPatchDto(Ingredient ingredient) {
+
+        if (ingredient == null) {
+            return null;
+        }
+
+        return IngredientPatchDto.builder()
+                .id(ingredient.getId())
+                .index(ingredient.getIdx())
+                .name(ingredient.getName())
+                .amount(ingredient.getAmount())
+                .isEssential(ingredient.isEssential())
+                .build();
+    }
+
+    @Override
+    public List<IngredientPatchDto> toPatchDto(List<Ingredient> ingredients) {
+
+        if(ingredients.isEmpty()){
+            return new ArrayList<>();
+        }
+
+        List<IngredientPatchDto> ingredientPatchDtoList = new ArrayList<>();
+
+        for(Ingredient ingredient : ingredients){
+            ingredientPatchDtoList.add(toPatchDto(ingredient));
+        }
+
+        return ingredientPatchDtoList;
     }
 
     @Override

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/IngredientMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/IngredientMapperImpl.java
@@ -53,7 +53,6 @@ public class IngredientMapperImpl implements IngredientMapper {
         }
 
         return IngredientPatchDto.builder()
-                .id(ingredient.getId())
                 .index(ingredient.getIdx())
                 .name(ingredient.getName())
                 .amount(ingredient.getAmount())

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
@@ -79,6 +79,7 @@ public class RecipeMapperImpl implements RecipeMapper {
         return RecipeInfoDto.builder()
                 .id(recipe.getId())
                 .title(recipe.getTitle())
+                .views(recipe.getViews())
                 .imgThumbNailUrl(recipe.getImgThumbNail().getFileName())
                 .stars(String.format("%.2f", recipe.getStars()))
                 .tags(tagMapper.toResponseDto(recipe.getTagList()))

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.*;
+import run.ward.mmz.dto.request.patch.RecipePatchDto;
 import run.ward.mmz.dto.request.post.RecipePostDto;
 import run.ward.mmz.dto.respones.RecipeInfoDto;
 import run.ward.mmz.dto.respones.RecipeResponseDto;
@@ -78,6 +79,25 @@ public class RecipeMapperImpl implements RecipeMapper {
                 .imgThumbNailUrl(recipe.getImgThumbNail().getFileName())
                 .stars(String.format("%.2f", recipe.getStars()))
                 .tags(tagMapper.toResponseDto(recipe.getTagList()))
+                .build();
+    }
+
+    @Override
+    public RecipePatchDto toPatchDto(Recipe recipe) {
+
+        if (recipe == null) {
+            return null;
+        }
+
+        return RecipePatchDto.builder()
+                .title(recipe.getTitle())
+                .body(recipe.getBody())
+                .category(recipe.getCategory())
+                .imgThumbNailUrl(recipe.getImgThumbNail().getFileName())
+                .level(recipe.getLevel())
+                .directions(directionMapper.toPatchDto(recipe.getDirections()))
+                .ingredients(ingredientMapper.toPatchDto(recipe.getIngredients()))
+                .tags(tagMapper.toPatchDto(recipe.getTagList()))
                 .build();
     }
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
@@ -9,6 +9,7 @@ import run.ward.mmz.dto.request.patch.RecipePatchDto;
 import run.ward.mmz.dto.request.post.RecipePostDto;
 import run.ward.mmz.dto.respones.RecipeInfoDto;
 import run.ward.mmz.dto.respones.RecipeResponseDto;
+import run.ward.mmz.mapper.account.AccountMapper;
 import run.ward.mmz.mapper.post.*;
 
 import java.util.List;
@@ -21,6 +22,7 @@ public class RecipeMapperImpl implements RecipeMapper {
     private final IngredientMapper ingredientMapper;
     private final TagMapper tagMapper;
     private final ReviewMapper reviewMapper;
+    private final AccountMapper accountMapper;
 
     @Override
     public Recipe toEntity(Account owner, RecipePostDto recipePostDto, Files imgThumbNail, List<Ingredient> ingredients, List<Direction> directionList) {
@@ -49,6 +51,7 @@ public class RecipeMapperImpl implements RecipeMapper {
         }
 
         return RecipeResponseDto.builder()
+                .owner(accountMapper.toInfoDto(recipe.getOwner()))
                 .id(recipe.getId())
                 .title(recipe.getTitle())
                 .body(recipe.getBody())

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/RecipeMapperImpl.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.post.*;
-import run.ward.mmz.dto.request.RecipePostDto;
+import run.ward.mmz.dto.request.post.RecipePostDto;
 import run.ward.mmz.dto.respones.RecipeInfoDto;
 import run.ward.mmz.dto.respones.RecipeResponseDto;
 import run.ward.mmz.mapper.post.*;
@@ -39,8 +39,9 @@ public class RecipeMapperImpl implements RecipeMapper {
         );
     }
 
+
     @Override
-    public RecipeResponseDto toResponseDto(Recipe recipe, List<Tag> tagList) {
+    public RecipeResponseDto toResponseDto(Recipe recipe) {
 
         if (recipe == null) {
             return null;
@@ -49,6 +50,7 @@ public class RecipeMapperImpl implements RecipeMapper {
         return RecipeResponseDto.builder()
                 .id(recipe.getId())
                 .title(recipe.getTitle())
+                .body(recipe.getBody())
                 .category(recipe.getCategory())
                 .imgThumbNailUrl(recipe.getImgThumbNail().getFileName())
                 .level(recipe.getLevel())
@@ -59,13 +61,13 @@ public class RecipeMapperImpl implements RecipeMapper {
                 .modifyDate(recipe.getModDate())
                 .directions(directionMapper.toResponseDto(recipe.getDirections()))
                 .ingredients(ingredientMapper.toResponseDto(recipe.getIngredients()))
-                .tags(tagMapper.toResponseDto(tagList))
+                .tags(tagMapper.toResponseDto(recipe.getTagList()))
                 .reviews(reviewMapper.toResponseDto(recipe.getReviews()))
                 .build();
     }
 
     @Override
-    public RecipeInfoDto toInfoDto(Recipe recipe, List<Tag> tagList) {
+    public RecipeInfoDto toInfoDto(Recipe recipe) {
 
         if (recipe == null) {
             return null;
@@ -75,7 +77,7 @@ public class RecipeMapperImpl implements RecipeMapper {
                 .title(recipe.getTitle())
                 .imgThumbNailUrl(recipe.getImgThumbNail().getFileName())
                 .stars(String.format("%.2f", recipe.getStars()))
-                .tags(tagMapper.toResponseDto(tagList))
+                .tags(tagMapper.toResponseDto(recipe.getTagList()))
                 .build();
     }
 }

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/ReviewMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/ReviewMapperImpl.java
@@ -1,18 +1,23 @@
 package run.ward.mmz.mapper.post.impl;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
 import run.ward.mmz.dto.request.post.ReviewPostDto;
 import run.ward.mmz.dto.respones.ReviewResponseDto;
+import run.ward.mmz.mapper.account.AccountMapper;
 import run.ward.mmz.mapper.post.ReviewMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@RequiredArgsConstructor
 public class ReviewMapperImpl implements ReviewMapper {
+
+    private final AccountMapper accountMapper;
 
     @Override
     public Review toEntity(ReviewPostDto reviewPostDto, Account owner, Recipe recipe) {
@@ -37,6 +42,7 @@ public class ReviewMapperImpl implements ReviewMapper {
         }
 
         return ReviewResponseDto.builder()
+                .owner(accountMapper.toInfoDto(review.getOwner()))
                 .id(review.getId())
                 .stars(review.getStars())
                 .body(review.getBody())

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/ReviewMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/ReviewMapperImpl.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
-import run.ward.mmz.dto.request.ReviewPostDto;
+import run.ward.mmz.dto.request.post.ReviewPostDto;
 import run.ward.mmz.dto.respones.ReviewResponseDto;
 import run.ward.mmz.mapper.post.ReviewMapper;
 

--- a/server/src/main/java/run/ward/mmz/mapper/post/impl/TagMapperImpl.java
+++ b/server/src/main/java/run/ward/mmz/mapper/post/impl/TagMapperImpl.java
@@ -1,9 +1,9 @@
 package run.ward.mmz.mapper.post.impl;
 
 import org.springframework.stereotype.Component;
-import run.ward.mmz.domain.post.RecipeTag;
 import run.ward.mmz.domain.post.Tag;
-import run.ward.mmz.dto.request.TagPostDto;
+import run.ward.mmz.dto.request.patch.TagPatchDto;
+import run.ward.mmz.dto.request.post.TagPostDto;
 import run.ward.mmz.dto.respones.TagResponseDto;
 import run.ward.mmz.mapper.post.TagMapper;
 
@@ -68,5 +68,33 @@ public class TagMapperImpl implements TagMapper {
         }
 
         return tagResponseDtoList;
+    }
+
+    @Override
+    public TagPatchDto toPatchDto(Tag tag) {
+
+        if (tag == null) {
+            return null;
+        }
+
+        return TagPatchDto.builder()
+                .name(tag.getName())
+                .build();
+    }
+
+    @Override
+    public List<TagPatchDto> toPatchDto(List<Tag> tagList) {
+
+        if (tagList.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<TagPatchDto> tagPatchDtoList = new ArrayList<>();
+
+        for (Tag tag : tagList) {
+            tagPatchDtoList.add(toPatchDto(tag));
+        }
+
+        return tagPatchDtoList;
     }
 }

--- a/server/src/main/java/run/ward/mmz/repository/BookmarkRepository.java
+++ b/server/src/main/java/run/ward/mmz/repository/BookmarkRepository.java
@@ -1,8 +1,12 @@
 package run.ward.mmz.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.post.Bookmark;
+import run.ward.mmz.domain.post.Recipe;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
+    boolean existsByOwnerAndRecipe(Account owner, Recipe recipe);
+    Bookmark findByOwnerAndRecipe(Account owner, Recipe recipe);
 }

--- a/server/src/main/java/run/ward/mmz/repository/RecipeRepository.java
+++ b/server/src/main/java/run/ward/mmz/repository/RecipeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import run.ward.mmz.domain.post.Direction;
 import run.ward.mmz.domain.post.Recipe;
+import run.ward.mmz.domain.post.Review;
 
 import java.util.List;
 import java.util.Set;
@@ -16,5 +17,8 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     Page<Recipe> findAllByCategory(String name, Pageable pageable);
     Page<Recipe> findAllByTitleContaining(String title, Pageable pageable);
     Set<Recipe> findAllByTitleContaining(String title);
+
+    @Query("select r from Review r where r.owner.id = :id")
+    Page<Recipe> findAllByOwnerId(Long id, Pageable pageable);
 
 }

--- a/server/src/main/java/run/ward/mmz/repository/RecipeTagRepository.java
+++ b/server/src/main/java/run/ward/mmz/repository/RecipeTagRepository.java
@@ -2,17 +2,8 @@ package run.ward.mmz.repository;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.RecipeTag;
-
-import java.util.List;
 
 public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
 
-    @Query("select r from RecipeTag r where r.tag.name = :name")
-    List<RecipeTag> findAllByTagName(String name);
-
-    @Query("select r from RecipeTag r where r.recipe.id = :id")
-    List<RecipeTag> findAllByRecipeId(Long id);
 }

--- a/server/src/main/java/run/ward/mmz/repository/ReviewRepository.java
+++ b/server/src/main/java/run/ward/mmz/repository/ReviewRepository.java
@@ -1,5 +1,7 @@
 package run.ward.mmz.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import run.ward.mmz.domain.post.Review;
@@ -9,4 +11,7 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("select r from Review r where r.recipe.id = :id order by r.id desc")
     List<Review> findAllByRecipeId(Long id);
+
+    @Query("select r from Review r where r.owner.id = :id")
+    Page<Review> findAllByOwnerId(Long id, Pageable pageable);
 }

--- a/server/src/main/java/run/ward/mmz/repository/TagRepository.java
+++ b/server/src/main/java/run/ward/mmz/repository/TagRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
+    boolean existsByName(String name);
     Tag getReferenceByName(String name);
     Tag findByName(String name);
 }

--- a/server/src/main/java/run/ward/mmz/repository/TagRepository.java
+++ b/server/src/main/java/run/ward/mmz/repository/TagRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
+    Tag getReferenceByName(String name);
     Tag findByName(String name);
 }

--- a/server/src/main/java/run/ward/mmz/service/AccountService.java
+++ b/server/src/main/java/run/ward/mmz/service/AccountService.java
@@ -1,0 +1,12 @@
+package run.ward.mmz.service;
+
+import run.ward.mmz.domain.account.Account;
+
+public interface AccountService {
+
+
+    Account findAccountById(Account account);
+
+
+
+}

--- a/server/src/main/java/run/ward/mmz/service/AccountService.java
+++ b/server/src/main/java/run/ward/mmz/service/AccountService.java
@@ -7,6 +7,4 @@ public interface AccountService {
 
     Account findAccountById(Account account);
 
-
-
 }

--- a/server/src/main/java/run/ward/mmz/service/AccountService.java
+++ b/server/src/main/java/run/ward/mmz/service/AccountService.java
@@ -1,10 +1,13 @@
 package run.ward.mmz.service;
 
 import run.ward.mmz.domain.account.Account;
+import run.ward.mmz.domain.post.Recipe;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 
 public interface AccountService {
 
-
-    Account findAccountById(Account account);
-
+    Account findById(Long id);
+    void verifyExistsId(Long id);
+    Account findVerifiedEntity(Long id);
 }

--- a/server/src/main/java/run/ward/mmz/service/BookmarkService.java
+++ b/server/src/main/java/run/ward/mmz/service/BookmarkService.java
@@ -10,4 +10,5 @@ public interface BookmarkService {
     void setBookmarked(Long recipeId, Long accountId);
     void undoBookmarked(Long recipeId, Long accountId);
     Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
+
 }

--- a/server/src/main/java/run/ward/mmz/service/BookmarkService.java
+++ b/server/src/main/java/run/ward/mmz/service/BookmarkService.java
@@ -1,0 +1,13 @@
+package run.ward.mmz.service;
+
+import org.springframework.data.domain.Page;
+import run.ward.mmz.domain.post.Recipe;
+
+import java.util.List;
+
+public interface BookmarkService {
+
+    void setBookmarked(Long recipeId, Long accountId);
+    void undoBookmarked(Long recipeId, Long accountId);
+    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
+}

--- a/server/src/main/java/run/ward/mmz/service/BookmarkService.java
+++ b/server/src/main/java/run/ward/mmz/service/BookmarkService.java
@@ -9,6 +9,6 @@ public interface BookmarkService {
 
     void setBookmarked(Long recipeId, Long accountId);
     void undoBookmarked(Long recipeId, Long accountId);
-    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy, String sort);
+    Page<Recipe> findAllBookmarkedRecipeByAccountId(int page, int size, Long accountId, String orderBy, String sort);
 
 }

--- a/server/src/main/java/run/ward/mmz/service/BookmarkService.java
+++ b/server/src/main/java/run/ward/mmz/service/BookmarkService.java
@@ -9,6 +9,6 @@ public interface BookmarkService {
 
     void setBookmarked(Long recipeId, Long accountId);
     void undoBookmarked(Long recipeId, Long accountId);
-    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
+    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy, String sort);
 
 }

--- a/server/src/main/java/run/ward/mmz/service/RecipeService.java
+++ b/server/src/main/java/run/ward/mmz/service/RecipeService.java
@@ -11,8 +11,8 @@ public interface RecipeService extends CrudService<Recipe> {
     List<Recipe> findAll();
     void updateStars(Long id);
     void addViews(Long id);
-    Page<Recipe> findAllByCategory(int page, int size, String category, String orderBy);
-    Page<Recipe> findAllBySearch(int page, int size, String search, String orderBy);
-    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
+    Page<Recipe> findAllByCategory(int page, int size, String category, String orderBy, String sort);
+    Page<Recipe> findAllBySearch(int page, int size, String search, String orderBy, String sort);
+    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy, String sort);
 
 }

--- a/server/src/main/java/run/ward/mmz/service/RecipeService.java
+++ b/server/src/main/java/run/ward/mmz/service/RecipeService.java
@@ -11,9 +11,8 @@ public interface RecipeService extends CrudService<Recipe> {
     List<Recipe> findAll();
     void updateStars(Long id);
     void addViews(Long id);
-
     Page<Recipe> findAllByCategory(int page, int size, String category, String orderBy);
     Page<Recipe> findAllBySearch(int page, int size, String search, String orderBy);
-
+    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
 
 }

--- a/server/src/main/java/run/ward/mmz/service/RecipeService.java
+++ b/server/src/main/java/run/ward/mmz/service/RecipeService.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public interface RecipeService extends CrudService<Recipe> {
 
+
+    void verifyAccessOwner(Long recipeId, Long accountId);
     List<Recipe> findAll();
     void updateStars(Long id);
     void addViews(Long id);

--- a/server/src/main/java/run/ward/mmz/service/RecipeTagService.java
+++ b/server/src/main/java/run/ward/mmz/service/RecipeTagService.java
@@ -9,5 +9,6 @@ public interface RecipeTagService {
     void save(List<Tag> tagList, Recipe recipe);
     List<Tag> findAllByRecipeId(Long recipeId);
     List<Recipe> findAllByTagName(String tagName);
+    void deleteAllByRecipe(Recipe recipe);
 
 }

--- a/server/src/main/java/run/ward/mmz/service/ReviewService.java
+++ b/server/src/main/java/run/ward/mmz/service/ReviewService.java
@@ -3,12 +3,16 @@ package run.ward.mmz.service;
 import org.springframework.data.domain.Page;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.service.common.CrudService;
 
 import java.util.List;
+import java.util.Objects;
 
 public interface ReviewService extends CrudService<Review> {
 
     List<Review> findAllByRecipeId(Long recipeId);
     Page<Review> findAllByAccountId(int page, int size, Long accountId, String orderBy);
+    void verifyAccessOwner(Long reviewId, Long accountId);
 }

--- a/server/src/main/java/run/ward/mmz/service/ReviewService.java
+++ b/server/src/main/java/run/ward/mmz/service/ReviewService.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface ReviewService extends CrudService<Review> {
 
     List<Review> findAllByRecipeId(Long recipeId);
-    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
+    Page<Review> findAllByAccountId(int page, int size, Long accountId, String orderBy);
 }

--- a/server/src/main/java/run/ward/mmz/service/ReviewService.java
+++ b/server/src/main/java/run/ward/mmz/service/ReviewService.java
@@ -1,5 +1,7 @@
 package run.ward.mmz.service;
 
+import org.springframework.data.domain.Page;
+import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
 import run.ward.mmz.service.common.CrudService;
 
@@ -8,4 +10,5 @@ import java.util.List;
 public interface ReviewService extends CrudService<Review> {
 
     List<Review> findAllByRecipeId(Long recipeId);
+    Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy);
 }

--- a/server/src/main/java/run/ward/mmz/service/TagService.java
+++ b/server/src/main/java/run/ward/mmz/service/TagService.java
@@ -13,4 +13,5 @@ public interface TagService{
 
     List<Tag> saveAll(List<Tag> tagList);
     Tag findByTagName(String tagName);
+
 }

--- a/server/src/main/java/run/ward/mmz/service/common/CrudService.java
+++ b/server/src/main/java/run/ward/mmz/service/common/CrudService.java
@@ -13,7 +13,6 @@ public interface CrudService<T>{
     void deleteById(Long id);
     T update(Long id, T t);
     void verifyExistsId(Long id);
-
     T findVerifiedEntity(Long id);
 
 }

--- a/server/src/main/java/run/ward/mmz/service/common/RecipeElementService.java
+++ b/server/src/main/java/run/ward/mmz/service/common/RecipeElementService.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 public interface RecipeElementService<T> extends CrudService<T> {
 
-    T findByRecipeId(Long recipeId);
+    void deleteAll(List<T> tList);
     List<T> findAllByRecipeId(Long recipeId);
-    void verifyExistsRecipeId(Long recipeId);
-
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/AccountServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/AccountServiceImpl.java
@@ -1,0 +1,36 @@
+package run.ward.mmz.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import run.ward.mmz.domain.account.Account;
+import run.ward.mmz.domain.post.Recipe;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
+import run.ward.mmz.repository.AccountRepository;
+import run.ward.mmz.service.AccountService;
+
+@Service
+@RequiredArgsConstructor
+public class AccountServiceImpl implements AccountService {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public Account findById(Long id) {
+        return findVerifiedEntity(id);
+    }
+
+    @Override
+    public void verifyExistsId(Long id) {
+        if (!accountRepository.existsById(id))
+            throw new CustomException(ExceptionCode.USER_NOT_FOUND);
+    }
+
+    @Override
+    public Account findVerifiedEntity(Long id) {
+
+        return accountRepository.findById(id).orElseThrow(
+                () -> new CustomException(ExceptionCode.USER_NOT_FOUND)
+        );
+    }
+}

--- a/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
@@ -77,7 +77,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy, String sort) {
+    public Page<Recipe> findAllBookmarkedRecipeByAccountId(int page, int size, Long accountId, String orderBy, String sort) {
 
         Sort bySort = Sort.by(orderBy).descending();
 

--- a/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
@@ -40,8 +40,16 @@ public class BookmarkServiceImpl implements BookmarkService {
             throw new CustomException(ExceptionCode.USER_ACCESS_DENIED);
 
         Bookmark bookmark = Bookmark.builder().build();
-        bookmark.setBookmarked(recipe, account);
-        bookmarkRepository.save(bookmark);
+
+        if(bookmarkRepository.existsByOwnerAndRecipe(account, recipe)) {
+            throw new CustomException(ExceptionCode.BOOKMARK_EXISTS);
+        }
+        else{
+            bookmark.setBookmarked(recipe, account);
+            bookmarkRepository.save(bookmark);
+        }
+
+
 
     }
 
@@ -55,9 +63,15 @@ public class BookmarkServiceImpl implements BookmarkService {
         if(!recipe.getOwner().getId().equals(accountId))
             throw new CustomException(ExceptionCode.USER_ACCESS_DENIED);
 
-        Bookmark bookmark = Bookmark.builder().build();
-        bookmark.removeBookmarked(recipe, account);
-        bookmarkRepository.delete(bookmark);
+        Bookmark bookmark = bookmarkRepository.findByOwnerAndRecipe(account, recipe);
+
+        if(bookmarkRepository.existsByOwnerAndRecipe(account, recipe)) {
+            bookmark.removeBookmarked(recipe, account);
+            bookmarkRepository.delete(bookmark);
+        }
+        else{
+            throw new CustomException(ExceptionCode.BOOKMARK_NOT_FOUND);
+        }
 
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
@@ -2,15 +2,24 @@ package run.ward.mmz.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.account.Account;
+import run.ward.mmz.domain.post.Bookmark;
 import run.ward.mmz.domain.post.Recipe;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.AccountRepository;
 import run.ward.mmz.repository.BookmarkRepository;
 import run.ward.mmz.repository.RecipeRepository;
 import run.ward.mmz.service.AccountService;
 import run.ward.mmz.service.BookmarkService;
 import run.ward.mmz.service.RecipeService;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,22 +30,52 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final AccountService accountService;
 
     @Override
+    @Transactional
     public void setBookmarked(Long recipeId, Long accountId) {
 
         Recipe recipe = recipeService.findById(recipeId);
         Account account = accountService.findById(accountId);
 
+        if(!recipe.getOwner().getId().equals(accountId))
+            throw new CustomException(ExceptionCode.USER_ACCESS_DENIED);
 
+        Bookmark bookmark = Bookmark.builder().build();
+        bookmark.setBookmarked(recipe, account);
+        bookmarkRepository.save(bookmark);
 
     }
 
     @Override
+    @Transactional
     public void undoBookmarked(Long recipeId, Long accountId) {
 
+        Recipe recipe = recipeService.findById(recipeId);
+        Account account = accountService.findById(accountId);
+
+        if(!recipe.getOwner().getId().equals(accountId))
+            throw new CustomException(ExceptionCode.USER_ACCESS_DENIED);
+
+        Bookmark bookmark = Bookmark.builder().build();
+        bookmark.removeBookmarked(recipe, account);
+        bookmarkRepository.delete(bookmark);
+
     }
 
     @Override
-    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy) {
-        return null;
+    @Transactional(readOnly = true)
+    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy, String sort) {
+
+        Sort bySort = Sort.by(orderBy).descending();
+
+        if (!sort.equals("dec"))
+            bySort = bySort.ascending();
+
+        List<Recipe> recipeList = accountService.findById(accountId).getRecipeList();
+
+        return new PageImpl<>(
+                recipeList,
+                PageRequest.of(page - 1, size, bySort),
+                recipeList.size()
+        );
     }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
@@ -1,13 +1,32 @@
 package run.ward.mmz.service.impl;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.post.Recipe;
+import run.ward.mmz.repository.AccountRepository;
+import run.ward.mmz.repository.BookmarkRepository;
+import run.ward.mmz.repository.RecipeRepository;
+import run.ward.mmz.service.AccountService;
 import run.ward.mmz.service.BookmarkService;
+import run.ward.mmz.service.RecipeService;
 
+@Service
+@RequiredArgsConstructor
 public class BookmarkServiceImpl implements BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final RecipeService recipeService;
+    private final AccountService accountService;
 
     @Override
     public void setBookmarked(Long recipeId, Long accountId) {
+
+        Recipe recipe = recipeService.findById(recipeId);
+        Account account = accountService.findById(accountId);
+
+
 
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/BookmarkServiceImpl.java
@@ -1,0 +1,23 @@
+package run.ward.mmz.service.impl;
+
+import org.springframework.data.domain.Page;
+import run.ward.mmz.domain.post.Recipe;
+import run.ward.mmz.service.BookmarkService;
+
+public class BookmarkServiceImpl implements BookmarkService {
+
+    @Override
+    public void setBookmarked(Long recipeId, Long accountId) {
+
+    }
+
+    @Override
+    public void undoBookmarked(Long recipeId, Long accountId) {
+
+    }
+
+    @Override
+    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy) {
+        return null;
+    }
+}

--- a/server/src/main/java/run/ward/mmz/service/impl/DirectionServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/DirectionServiceImpl.java
@@ -30,18 +30,21 @@ public class DirectionServiceImpl implements DirectionService {
     }
 
     @Override
+    @Transactional
     public Direction save(Direction direction) {
         return directionRepository.save(direction);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Direction findById(Long id) {
-        return null;
+        return directionRepository.getReferenceById(id);
     }
 
     @Override
+    @Transactional
     public void deleteById(Long id) {
-
+        directionRepository.deleteById(id);
     }
 
     @Override
@@ -61,18 +64,17 @@ public class DirectionServiceImpl implements DirectionService {
 
     //Recipe Element Service
 
+
     @Override
-    public Direction findByRecipeId(Long recipeId) {
-        return null;
+    @Transactional
+    public void deleteAll(List<Direction> directions) {
+        directionRepository.deleteAll(directions);
     }
 
     @Override
     public List<Direction> findAllByRecipeId(Long recipeId) {
-        return null;
+
+        return directionRepository.findAllByRecipeId(recipeId);
     }
 
-    @Override
-    public void verifyExistsRecipeId(Long recipeId) {
-
-    }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/DirectionServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/DirectionServiceImpl.java
@@ -56,12 +56,14 @@ public class DirectionServiceImpl implements DirectionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void verifyExistsId(Long id) {
         if(!directionRepository.existsById(id))
             throw new CustomException(ExceptionCode.DIRECTION_NOT_FOUND);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Direction findVerifiedEntity(Long id) {
         return directionRepository.findById(id).orElseThrow(
                 () -> new CustomException(ExceptionCode.DIRECTION_NOT_FOUND)

--- a/server/src/main/java/run/ward/mmz/service/impl/DirectionServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/DirectionServiceImpl.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.post.Direction;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.DirectionRepository;
 import run.ward.mmz.service.DirectionService;
 import run.ward.mmz.service.ImageService;
+import run.ward.mmz.service.RecipeService;
 
 import java.util.List;
 
@@ -54,16 +57,18 @@ public class DirectionServiceImpl implements DirectionService {
 
     @Override
     public void verifyExistsId(Long id) {
-
+        if(!directionRepository.existsById(id))
+            throw new CustomException(ExceptionCode.DIRECTION_NOT_FOUND);
     }
 
     @Override
     public Direction findVerifiedEntity(Long id) {
-        return null;
+        return directionRepository.findById(id).orElseThrow(
+                () -> new CustomException(ExceptionCode.DIRECTION_NOT_FOUND)
+        );
     }
 
     //Recipe Element Service
-
 
     @Override
     @Transactional
@@ -73,7 +78,6 @@ public class DirectionServiceImpl implements DirectionService {
 
     @Override
     public List<Direction> findAllByRecipeId(Long recipeId) {
-
         return directionRepository.findAllByRecipeId(recipeId);
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/ImageServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/ImageServiceImpl.java
@@ -22,7 +22,6 @@ public class ImageServiceImpl implements ImageService {
     private final FileRepository fileRepository;
 
     @Override
-    @Transactional
     public List<Files> saveAll(List<MultipartFile> multipartFiles) {
 
         List<String> imgExtension = ImageType.EXTENSIONS;

--- a/server/src/main/java/run/ward/mmz/service/impl/IngredientServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/IngredientServiceImpl.java
@@ -29,7 +29,7 @@ public class IngredientServiceImpl implements IngredientService {
 
     @Override
     public Ingredient findById(Long id) {
-        return ingredientRepository.getReferenceById(id);
+        return findVerifiedEntity(id);
     }
 
     @Override
@@ -51,6 +51,9 @@ public class IngredientServiceImpl implements IngredientService {
 
     @Override
     public Ingredient findVerifiedEntity(Long id) {
+        ingredientRepository.findById(id).orElseThrow(
+                () -> new CustomException(ExceptionCode.INGREDIENT_NOT_FOUND)
+        );
         return null;
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/IngredientServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/IngredientServiceImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.post.Ingredient;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.IngredientRepository;
 import run.ward.mmz.service.IngredientService;
 
@@ -27,12 +29,13 @@ public class IngredientServiceImpl implements IngredientService {
 
     @Override
     public Ingredient findById(Long id) {
-        return null;
+        return ingredientRepository.getReferenceById(id);
     }
 
     @Override
+    @Transactional
     public void deleteById(Long id) {
-
+        ingredientRepository.deleteById(id);
     }
 
     @Override
@@ -42,7 +45,8 @@ public class IngredientServiceImpl implements IngredientService {
 
     @Override
     public void verifyExistsId(Long id) {
-
+        if(!ingredientRepository.existsById(id))
+            throw new CustomException(ExceptionCode.INGREDIENT_NOT_FOUND);
     }
 
     @Override
@@ -51,17 +55,15 @@ public class IngredientServiceImpl implements IngredientService {
     }
 
     @Override
-    public Ingredient findByRecipeId(Long recipeId) {
-        return null;
+    @Transactional
+    public void deleteAll(List<Ingredient> ingredients) {
+        ingredientRepository.deleteAll(ingredients);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Ingredient> findAllByRecipeId(Long recipeId) {
-        return null;
+        return ingredientRepository.findAllByRecipeId(recipeId);
     }
 
-    @Override
-    public void verifyExistsRecipeId(Long recipeId) {
-
-    }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
@@ -97,16 +97,28 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
-    public Page<Recipe> findAllByCategory(int page, int size, String category, String orderBy) {
+    @Transactional(readOnly = true)
+    public Page<Recipe> findAllByCategory(int page, int size, String category, String orderBy, String sort) {
+
+        Sort bySort = Sort.by(orderBy).descending();
+
+        if(!sort.equals("dec"))
+            bySort = bySort.ascending();
 
         return recipeRepository.findAllByCategory(
                 category,
-                PageRequest.of(page - 1 , size, Sort.by(orderBy).descending())
+                PageRequest.of(page - 1 , size, bySort)
         );
     }
 
     @Override
-    public Page<Recipe> findAllBySearch(int page, int size, String search, String orderBy) {
+    @Transactional(readOnly = true)
+    public Page<Recipe> findAllBySearch(int page, int size, String search, String orderBy, String sort) {
+
+        Sort bySort = Sort.by(orderBy).descending();
+
+        if(!sort.equals("dec"))
+            bySort = bySort.ascending();
 
         Set<Recipe> recipeSet = new HashSet<>();
         recipeSet.addAll(recipeRepository.findAllByTitleContaining(search));
@@ -116,14 +128,20 @@ public class RecipeServiceImpl implements RecipeService {
 
         return new PageImpl<>(
                 recipeList,
-                PageRequest.of(page - 1, size, Sort.by(orderBy).descending()),
+                PageRequest.of(page - 1, size, bySort),
                 recipeSet.size()
         );
 
     }
 
     @Override
-    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy) {
+    @Transactional(readOnly = true)
+    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy, String sort) {
+
+        Sort bySort = Sort.by(orderBy).descending();
+
+        if(!sort.equals("dec"))
+            bySort = bySort.ascending();
 
         return recipeRepository.findAllByOwnerId(
                 accountId,

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
@@ -119,9 +119,15 @@ public class RecipeServiceImpl implements RecipeService {
                 PageRequest.of(page - 1, size, Sort.by(orderBy).descending()),
                 recipeSet.size()
         );
-//        return recipeRepository.findAllByTitleContaining(
-//                search,
-//                PageRequest.of(page - 1 , size, Sort.by(orderBy).descending())
-//        );
+
+    }
+
+    @Override
+    public Page<Recipe> findAllByAccountId(int page, int size, Long accountId, String orderBy) {
+
+        return recipeRepository.findAllByOwnerId(
+                accountId,
+                PageRequest.of(page - 1 , size, Sort.by(orderBy).descending())
+        );
     }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
@@ -38,7 +38,7 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     @Transactional
     public Recipe save(Recipe recipe) {
-        verifyExistsId(recipe.getId());
+
         ingredientService.saveAll(recipe.getIngredients());
         directionService.saveAll(recipe.getDirections());
         return recipeRepository.save(recipe);
@@ -47,8 +47,7 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     @Transactional(readOnly = true)
     public Recipe findById(Long id) {
-        //proxy 조회(영속성 컨텍스트에서 조회된다.)
-        return recipeRepository.getReferenceById(id);
+        return findVerifiedEntity(id);
     }
 
     @Override

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Tag;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.RecipeRepository;
 import run.ward.mmz.service.*;
 
@@ -36,6 +38,7 @@ public class RecipeServiceImpl implements RecipeService {
     @Override
     @Transactional
     public Recipe save(Recipe recipe) {
+        verifyExistsId(recipe.getId());
         ingredientService.saveAll(recipe.getIngredients());
         directionService.saveAll(recipe.getDirections());
         return recipeRepository.save(recipe);
@@ -55,19 +58,25 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     public Recipe update(Long id, Recipe recipe) {
+
+        Recipe updateRecipe = recipeRepository.getReferenceById(id);
+
+
+
         return null;
     }
 
     @Override
     public void verifyExistsId(Long id) {
-
+        if(!recipeRepository.existsById(id))
+            throw new CustomException(ExceptionCode.RECIPE_NOT_FOUND);
     }
 
     @Override
     public Recipe findVerifiedEntity(Long id) {
 
         return recipeRepository.findById(id).orElseThrow(
-                //ToDo : exception
+            () -> new CustomException(ExceptionCode.RECIPE_NOT_FOUND)
         );
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
@@ -14,10 +14,7 @@ import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.RecipeRepository;
 import run.ward.mmz.service.*;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -52,7 +49,7 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     public void deleteById(Long id) {
-
+        recipeRepository.deleteById(id);
     }
 
     @Override
@@ -61,13 +58,12 @@ public class RecipeServiceImpl implements RecipeService {
         Recipe updateRecipe = recipeRepository.getReferenceById(id);
 
 
-
         return null;
     }
 
     @Override
     public void verifyExistsId(Long id) {
-        if(!recipeRepository.existsById(id))
+        if (!recipeRepository.existsById(id))
             throw new CustomException(ExceptionCode.RECIPE_NOT_FOUND);
     }
 
@@ -75,8 +71,15 @@ public class RecipeServiceImpl implements RecipeService {
     public Recipe findVerifiedEntity(Long id) {
 
         return recipeRepository.findById(id).orElseThrow(
-            () -> new CustomException(ExceptionCode.RECIPE_NOT_FOUND)
+                () -> new CustomException(ExceptionCode.RECIPE_NOT_FOUND)
         );
+    }
+
+    @Override
+    public void verifyAccessOwner(Long recipeId, Long accountId) {
+        Long ownerId = findVerifiedEntity(recipeId).getOwner().getId();
+        if (!Objects.equals(ownerId, accountId))
+            throw new CustomException(ExceptionCode.USER_ACCESS_DENIED);
     }
 
     @Override
@@ -102,12 +105,12 @@ public class RecipeServiceImpl implements RecipeService {
 
         Sort bySort = Sort.by(orderBy).descending();
 
-        if(!sort.equals("dec"))
+        if (!sort.equals("dec"))
             bySort = bySort.ascending();
 
         return recipeRepository.findAllByCategory(
                 category,
-                PageRequest.of(page - 1 , size, bySort)
+                PageRequest.of(page - 1, size, bySort)
         );
     }
 
@@ -117,7 +120,7 @@ public class RecipeServiceImpl implements RecipeService {
 
         Sort bySort = Sort.by(orderBy).descending();
 
-        if(!sort.equals("dec"))
+        if (!sort.equals("dec"))
             bySort = bySort.ascending();
 
         Set<Recipe> recipeSet = new HashSet<>();
@@ -140,12 +143,12 @@ public class RecipeServiceImpl implements RecipeService {
 
         Sort bySort = Sort.by(orderBy).descending();
 
-        if(!sort.equals("dec"))
+        if (!sort.equals("dec"))
             bySort = bySort.ascending();
 
         return recipeRepository.findAllByOwnerId(
                 accountId,
-                PageRequest.of(page - 1 , size, Sort.by(orderBy).descending())
+                PageRequest.of(page - 1, size, Sort.by(orderBy).descending())
         );
     }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeServiceImpl.java
@@ -48,11 +48,13 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional
     public void deleteById(Long id) {
         recipeRepository.deleteById(id);
     }
 
     @Override
+    @Transactional
     public Recipe update(Long id, Recipe recipe) {
 
         Recipe updateRecipe = recipeRepository.getReferenceById(id);
@@ -62,12 +64,14 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void verifyExistsId(Long id) {
         if (!recipeRepository.existsById(id))
             throw new CustomException(ExceptionCode.RECIPE_NOT_FOUND);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Recipe findVerifiedEntity(Long id) {
 
         return recipeRepository.findById(id).orElseThrow(
@@ -76,6 +80,7 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void verifyAccessOwner(Long recipeId, Long accountId) {
         Long ownerId = findVerifiedEntity(recipeId).getOwner().getId();
         if (!Objects.equals(ownerId, accountId))
@@ -83,6 +88,7 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Recipe> findAll() {
         return recipeRepository.findAll();
     }

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.RecipeTag;
 import run.ward.mmz.domain.post.Tag;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.RecipeRepository;
 import run.ward.mmz.repository.RecipeTagRepository;
 import run.ward.mmz.repository.TagRepository;
@@ -43,14 +45,20 @@ public class RecipeTagServiceImpl implements RecipeTagService {
     @Override
     @Transactional(readOnly = true)
     public List<Tag> findAllByRecipeId(Long recipeId) {
-        //ToDo : recipeId 없을 경우 예외처리 필요
+        //recipeId 없을 경우 예외처리 완료
+        if(!recipeRepository.existsById(recipeId))
+            throw new CustomException(ExceptionCode.RECIPE_NOT_FOUND);
+
         return recipeRepository.getReferenceById(recipeId).getTagList();
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<Recipe> findAllByTagName(String tagName) {
-        //ToDo : tagName 없을 경우 예외처리 필요
+        //tagName 없을 경우 예외처리 필요 완료
+        if(!tagRepository.existsByName(tagName))
+            throw new CustomException(ExceptionCode.TAG_NOT_FOUND);
+
         return tagRepository.getReferenceByName(tagName).getRecipeList();
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
@@ -44,31 +44,14 @@ public class RecipeTagServiceImpl implements RecipeTagService {
     @Transactional(readOnly = true)
     public List<Tag> findAllByRecipeId(Long recipeId) {
 
-        List<RecipeTag> recipeTagList = recipeTagRepository.findAllByRecipeId(recipeId);
-
-        return recipeTagList.stream()
-                .map(
-                        recipeTag -> {
-                            Optional<Tag> tag = tagRepository.findById(recipeTag.getTag().getId());
-                            return tag.orElse(null);
-                        })
-                .collect(Collectors.toList());
+        return recipeRepository.getReferenceById(recipeId).getTagList();
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<Recipe> findAllByTagName(String tagName) {
 
-        List<RecipeTag> recipeTagList = recipeTagRepository.findAllByTagName(tagName);
-
-        return recipeTagList.stream()
-                .map(
-                        recipeTag -> {
-                            Optional<Recipe> recipe = recipeRepository.findById(recipeTag.getRecipe().getId());
-                            return recipe.orElse(null);
-                        })
-                .collect(Collectors.toList());
-
+        return tagRepository.getReferenceByName(tagName).getRecipeList();
     }
 
 

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
@@ -43,14 +43,14 @@ public class RecipeTagServiceImpl implements RecipeTagService {
     @Override
     @Transactional(readOnly = true)
     public List<Tag> findAllByRecipeId(Long recipeId) {
-
+        //ToDo : recipeId 없을 경우 예외처리 필요
         return recipeRepository.getReferenceById(recipeId).getTagList();
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<Recipe> findAllByTagName(String tagName) {
-
+        //ToDo : tagName 없을 경우 예외처리 필요
         return tagRepository.getReferenceByName(tagName).getRecipeList();
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/RecipeTagServiceImpl.java
@@ -54,5 +54,10 @@ public class RecipeTagServiceImpl implements RecipeTagService {
         return tagRepository.getReferenceByName(tagName).getRecipeList();
     }
 
+    @Override
+    public void deleteAllByRecipe(Recipe recipe) {
+//        recipe.deleteAllRecipeTag();
+    }
+
 
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.post.Review;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.ReviewRepository;
+import run.ward.mmz.service.RecipeService;
 import run.ward.mmz.service.ReviewService;
 
 import java.util.List;
@@ -12,7 +15,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
-
     private final ReviewRepository reviewRepository;
 
     @Override
@@ -23,18 +25,17 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     @Transactional
     public Review save(Review review) {
-
         return reviewRepository.save(review);
     }
 
     @Override
     public Review findById(Long id) {
-        return null;
+        return findVerifiedEntity(id);
     }
 
     @Override
     public void deleteById(Long id) {
-
+        reviewRepository.deleteById(id);
     }
 
     @Override
@@ -44,12 +45,15 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public void verifyExistsId(Long id) {
-
+        if (!reviewRepository.existsById(id))
+            throw new CustomException(ExceptionCode.REVIEW_NOT_FOUND);
     }
 
     @Override
     public Review findVerifiedEntity(Long id) {
-        return null;
+        return reviewRepository.findById(id).orElseThrow(
+                () -> new CustomException(ExceptionCode.REVIEW_NOT_FOUND)
+        );
     }
 
     @Override

--- a/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
@@ -15,6 +15,7 @@ import run.ward.mmz.service.RecipeService;
 import run.ward.mmz.service.ReviewService;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -72,5 +73,12 @@ public class ReviewServiceImpl implements ReviewService {
                 accountId,
                 PageRequest.of(page - 1 , size, Sort.by(orderBy).descending())
         );
+    }
+
+    @Override
+    public void verifyAccessOwner(Long reviewId, Long accountId) {
+        Long ownerId = findVerifiedEntity(reviewId).getOwner().getId();
+        if (!Objects.equals(ownerId, accountId))
+            throw new CustomException(ExceptionCode.USER_ACCESS_DENIED);
     }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
@@ -1,8 +1,12 @@
 package run.ward.mmz.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import run.ward.mmz.domain.post.Recipe;
 import run.ward.mmz.domain.post.Review;
 import run.ward.mmz.handler.exception.CustomException;
 import run.ward.mmz.handler.exception.ExceptionCode;
@@ -59,5 +63,14 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     public List<Review> findAllByRecipeId(Long recipeId) {
         return reviewRepository.findAllByRecipeId(recipeId);
+    }
+
+    @Override
+    public Page<Review> findAllByAccountId(int page, int size, Long accountId, String orderBy) {
+
+        return reviewRepository.findAllByOwnerId(
+                accountId,
+                PageRequest.of(page - 1 , size, Sort.by(orderBy).descending())
+        );
     }
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/ReviewServiceImpl.java
@@ -23,6 +23,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
 
     @Override
+    @Transactional
     public List<Review> saveAll(List<Review> list) {
         return null;
     }
@@ -34,27 +35,32 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Review findById(Long id) {
         return findVerifiedEntity(id);
     }
 
     @Override
+    @Transactional
     public void deleteById(Long id) {
         reviewRepository.deleteById(id);
     }
 
     @Override
+    @Transactional
     public Review update(Long id, Review review) {
         return null;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void verifyExistsId(Long id) {
         if (!reviewRepository.existsById(id))
             throw new CustomException(ExceptionCode.REVIEW_NOT_FOUND);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Review findVerifiedEntity(Long id) {
         return reviewRepository.findById(id).orElseThrow(
                 () -> new CustomException(ExceptionCode.REVIEW_NOT_FOUND)
@@ -62,11 +68,13 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Review> findAllByRecipeId(Long recipeId) {
         return reviewRepository.findAllByRecipeId(recipeId);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<Review> findAllByAccountId(int page, int size, Long accountId, String orderBy) {
 
         return reviewRepository.findAllByOwnerId(
@@ -76,6 +84,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void verifyAccessOwner(Long reviewId, Long accountId) {
         Long ownerId = findVerifiedEntity(reviewId).getOwner().getId();
         if (!Objects.equals(ownerId, accountId))

--- a/server/src/main/java/run/ward/mmz/service/impl/TagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/TagServiceImpl.java
@@ -38,4 +38,5 @@ public class TagServiceImpl implements TagService {
     }
 
 
+
 }

--- a/server/src/main/java/run/ward/mmz/service/impl/TagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/TagServiceImpl.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import run.ward.mmz.domain.post.Tag;
+import run.ward.mmz.handler.exception.CustomException;
+import run.ward.mmz.handler.exception.ExceptionCode;
 import run.ward.mmz.repository.TagRepository;
 import run.ward.mmz.service.TagService;
 
@@ -34,6 +36,10 @@ public class TagServiceImpl implements TagService {
 
     @Transactional
     public Tag findByTagName(String tagName) {
+
+        if(!tagRepository.existsByName(tagName))
+            throw new CustomException(ExceptionCode.TAG_NOT_FOUND);
+
         return tagRepository.findByName(tagName);
     }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/TagServiceImpl.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/TagServiceImpl.java
@@ -26,7 +26,7 @@ public class TagServiceImpl implements TagService {
         List<Tag> tagSave = new ArrayList<>();
 
         for(Tag tag : tagList){
-            if(findByTagName(tag.getName()) == null)
+            if(!tagRepository.existsByName(tag.getName()))
                 tagSave.add(tagRepository.save(tag));
         }
 

--- a/server/src/main/java/run/ward/mmz/service/impl/TestAccountService.java
+++ b/server/src/main/java/run/ward/mmz/service/impl/TestAccountService.java
@@ -2,6 +2,7 @@ package run.ward.mmz.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.repository.AccountRepository;
 
@@ -10,6 +11,7 @@ import run.ward.mmz.repository.AccountRepository;
 public class TestAccountService {
     private final AccountRepository accountRepository;
 
+    @Transactional
     public Account save(Account account) {
 
         return accountRepository.save(account);

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/BookmarkController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/BookmarkController.java
@@ -17,6 +17,7 @@ import run.ward.mmz.service.BookmarkService;
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
+
     @PostMapping("/recipe/{recipeId}/bookmark")
     public ResponseEntity<?> bookmarked(
             Account account,

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/BookmarkController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/BookmarkController.java
@@ -1,13 +1,41 @@
 package run.ward.mmz.web.controller.v1;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import run.ward.mmz.domain.account.Account;
+import run.ward.mmz.domain.post.Bookmark;
+import run.ward.mmz.service.BookmarkService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+    @PostMapping("/recipe/{recipeId}/bookmark")
+    public ResponseEntity<?> bookmarked(
+            Account account,
+            @PathVariable Long recipeId){
+
+        bookmarkService.setBookmarked(recipeId, 1L);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/recipe/{recipeId}/bookmark/undo")
+    public ResponseEntity<?> undoBookmarked(
+            Account account,
+            @PathVariable Long recipeId){
+
+        bookmarkService.undoBookmarked(recipeId, 1L);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 
 
 

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/BookmarkController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/BookmarkController.java
@@ -1,0 +1,14 @@
+package run.ward.mmz.web.controller.v1;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class BookmarkController {
+
+
+
+}

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
@@ -57,19 +57,19 @@ public class RecipeController {
 
     @PostMapping("/recipe/add")
     public ResponseEntity<?> postRecipePage(
-            Account owner,
+            Account user,
             @RequestPart(value = "imgThumbNail", required = false) MultipartFile imgThumbNail,
             @RequestPart(value = "imgDirection", required = false) List<MultipartFile> imgDirectionList,
             @RequestPart(value = "recipe") RecipePostDto recipePostDto) {
 
         //Test account
 
-        owner.setId(1L);
-        owner.setName("와드");
-        owner.setBio("와드입니다.");
-        owner.setEmail("ward@ward.run");
-        owner.setRole(Role.USER);
-        Account testOwner = testAccountService.save(owner);
+        user.setId(1L);
+        user.setName("와드");
+        user.setBio("와드입니다.");
+        user.setEmail("ward@ward.run");
+        user.setRole(Role.USER);
+        Account testOwner = testAccountService.save(user);
 
         //Controller Code
 
@@ -109,12 +109,11 @@ public class RecipeController {
 
     @GetMapping("/recipe/{recipeId}/edit")
     public ResponseEntity<?> readRecipeUpdatePage(
-            Account owner,
+            Account user,
             @PathVariable Long recipeId){
 
-        //ToDo : 해당 유저가 owner인지 확인하는 로직 필요
+        recipeService.verifyAccessOwner(recipeId, user.getId());
 
-        recipeService.verifyExistsId(recipeId);
         Recipe recipe = recipeService.findById(recipeId);
 
         ResponseDto.Single<?> response = ResponseDto.Single.builder()
@@ -126,14 +125,13 @@ public class RecipeController {
 
     @PatchMapping("/recipe/{recipeId}/edit")
     public ResponseEntity<?> updateRecipePage(
-            Account owner,
+            Account user,
             @PathVariable Long recipeId,
             @RequestPart(value = "imgThumbNail", required = false) MultipartFile imgThumbNail,
             @RequestPart(value = "imgDirection", required = false) List<MultipartFile> imgDirectionList,
             @RequestPart(value = "recipe") RecipePatchDto recipePatchDto ){
 
-        recipeService.verifyExistsId(recipeId);
-        //ToDo : 해당 유저가 owner인지 확인하는 로직 필요
+        recipeService.verifyAccessOwner(recipeId, user.getId());
 
         Files imgThumbNailFile = filesMapper.fileDtoToImage(fileHandler.parseFileInfo(imgThumbNail, ImageType.EXTENSIONS));
         List<Files> imgDirections = filesMapper.fileDtoListToImageList(fileHandler.parseFileInfo(imgDirectionList, ImageType.EXTENSIONS));
@@ -142,6 +140,18 @@ public class RecipeController {
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @DeleteMapping("/recipe/{recipeId}/delete")
+    public ResponseEntity<?> deleteRecipePage(
+            Account owner,
+            @PathVariable Long recipeId) {
+
+        recipeService.verifyAccessOwner(recipeId, 1L);
+        recipeService.deleteById(recipeId);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
 
 
     @GetMapping("/recipe/search/{pageNo}")

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
@@ -140,9 +140,6 @@ public class RecipeController {
 
 
 
-
-
-
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
@@ -151,9 +148,10 @@ public class RecipeController {
     public ResponseEntity<?> readSearchPage(
             @Positive @PathVariable(required = false, value = "pageNo") int pageNo,
             @RequestParam(required = false, defaultValue = "id", value = "orderBy") String orderBy,
-            @RequestParam("search") String search) {
+            @RequestParam("search") String search,
+            @RequestParam(required = false, defaultValue = "dec", value = "sort") String sort) {
 
-        Page<Recipe> recipePage = recipeService.findAllBySearch(pageNo, PAGE_SIZE, search, orderBy);
+        Page<Recipe> recipePage = recipeService.findAllBySearch(pageNo, PAGE_SIZE, search, orderBy, sort);
         List<Recipe> recipeList = recipePage.getContent();
         List<RecipeInfoDto> responseDtoList = new ArrayList<>();
 
@@ -173,10 +171,11 @@ public class RecipeController {
     public ResponseEntity<?> readCategoryPage(
             @Positive @PathVariable(required = false, value = "pageNo") int pageNo,
             @RequestParam(required = false, defaultValue = "id", value = "orderBy") String orderBy,
-            @RequestParam("category") String category) {
+            @RequestParam("category") String category,
+            @RequestParam(required = false, defaultValue = "dec", value = "sort") String sort) {
 
 
-        Page<Recipe> recipePage = recipeService.findAllByCategory(pageNo, PAGE_SIZE, category, orderBy);
+        Page<Recipe> recipePage = recipeService.findAllByCategory(pageNo, PAGE_SIZE, category, orderBy, sort);
         List<Recipe> recipeList = recipePage.getContent();
         List<RecipeInfoDto> responseDtoList = new ArrayList<>();
 

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
@@ -12,7 +12,7 @@ import run.ward.mmz.domain.account.Role;
 import run.ward.mmz.domain.file.Files;
 import run.ward.mmz.domain.file.Image.ImageType;
 import run.ward.mmz.domain.post.*;
-import run.ward.mmz.dto.request.RecipePostDto;
+import run.ward.mmz.dto.request.post.RecipePostDto;
 import run.ward.mmz.dto.common.ResponseDto;
 import run.ward.mmz.dto.respones.RecipeInfoDto;
 import run.ward.mmz.dto.respones.RecipeResponseDto;
@@ -50,11 +50,10 @@ public class RecipeController {
     private final RecipeService recipeService;
     private final TagService tagService;
     private final RecipeTagService recipeTagService;
-
     private final TestAccountService testAccountService;
 
     @PostMapping("/recipe/add")
-    public ResponseEntity<?> postRecipe(
+    public ResponseEntity<?> postRecipePage(
             Account owner,
             @RequestPart(value = "imgThumbNail", required = false) MultipartFile imgThumbNail,
             @RequestPart(value = "imgDirection", required = false) List<MultipartFile> imgDirectionList,
@@ -90,7 +89,7 @@ public class RecipeController {
     private static final int PAGE_SIZE = 12;
 
     @GetMapping("/recipe/{recipeId}")
-    public ResponseEntity<?> readRecipe(
+    public ResponseEntity<?> readRecipePage(
             @PathVariable Long recipeId) {
 
         recipeService.verifyExistsId(recipeId); //레시피가 있는 지 예외 처리
@@ -98,14 +97,40 @@ public class RecipeController {
         Recipe recipe = recipeService.findById(recipeId);
         recipeService.addViews(recipeId);
 
-        RecipeResponseDto responseDto = recipeMapper.toResponseDto(recipe, recipeTagService.findAllByRecipeId(recipeId));
+        RecipeResponseDto responseDto = recipeMapper.toResponseDto(recipe);
         ResponseDto.Single<?> response = ResponseDto.Single.builder()
                 .data(responseDto)
                 .build();
 
         return new ResponseEntity<>(response, HttpStatus.OK);
-
     }
+
+    @GetMapping("/recipe/{recipeId}/edit")
+    public ResponseEntity<?> readRecipeUpdatePage(
+            Account owner,
+            @PathVariable Long recipeId){
+
+        recipeService.verifyExistsId(recipeId);
+        //ToDo : 해당 유저가 owner인지 확인하는 로직 필요
+
+        Recipe recipe = recipeService.findById(recipeId);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PatchMapping("/recipe/{recipeId}/edit")
+    public ResponseEntity<?> updateRecipePage(
+            Account owner,
+            @PathVariable Long recipeId){
+
+        recipeService.verifyExistsId(recipeId);
+        //ToDo : 해당 유저가 owner인지 확인하는 로직 필요
+
+
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
 
     @GetMapping("/recipe/search/{pageNo}")
     public ResponseEntity<?> readSearchPage(
@@ -118,7 +143,7 @@ public class RecipeController {
         List<RecipeInfoDto> responseDtoList = new ArrayList<>();
 
         for(Recipe recipe : recipeList){
-            responseDtoList.add(recipeMapper.toInfoDto(recipe, recipeTagService.findAllByRecipeId(recipe.getId())));
+            responseDtoList.add(recipeMapper.toInfoDto(recipe));
         }
 
         ResponseDto.Multi<?> response = ResponseDto.Multi.builder()
@@ -141,7 +166,7 @@ public class RecipeController {
         List<RecipeInfoDto> responseDtoList = new ArrayList<>();
 
         for(Recipe recipe : recipeList){
-            responseDtoList.add(recipeMapper.toInfoDto(recipe, recipeTagService.findAllByRecipeId(recipe.getId())));
+            responseDtoList.add(recipeMapper.toInfoDto(recipe));
         }
 
         ResponseDto.Multi<?> response = ResponseDto.Multi.builder()

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
@@ -112,12 +112,16 @@ public class RecipeController {
             Account owner,
             @PathVariable Long recipeId){
 
-        recipeService.verifyExistsId(recipeId);
         //ToDo : 해당 유저가 owner인지 확인하는 로직 필요
 
+        recipeService.verifyExistsId(recipeId);
         Recipe recipe = recipeService.findById(recipeId);
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        ResponseDto.Single<?> response = ResponseDto.Single.builder()
+                .data(recipeMapper.toPatchDto(recipe))
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @PatchMapping("/recipe/{recipeId}/edit")

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/RecipeController.java
@@ -192,6 +192,7 @@ public class RecipeController {
     public ResponseEntity<?> deleteTags(
             @PathVariable Long recipeId) {
 
+        recipeService.verifyExistsId(recipeId);
         recipeTagService.deleteAllByRecipe(recipeService.findById(recipeId));
 
         return new ResponseEntity<>(HttpStatus.OK);

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/ReviewController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/ReviewController.java
@@ -9,7 +9,7 @@ import run.ward.mmz.domain.account.Account;
 import run.ward.mmz.domain.account.Role;
 import run.ward.mmz.domain.post.Review;
 import run.ward.mmz.dto.common.ResponseDto;
-import run.ward.mmz.dto.request.ReviewPostDto;
+import run.ward.mmz.dto.request.post.ReviewPostDto;
 import run.ward.mmz.dto.respones.ReviewResponseDto;
 import run.ward.mmz.mapper.post.ReviewMapper;
 import run.ward.mmz.service.RecipeService;

--- a/server/src/main/java/run/ward/mmz/web/controller/v1/ReviewController.java
+++ b/server/src/main/java/run/ward/mmz/web/controller/v1/ReviewController.java
@@ -32,23 +32,24 @@ public class ReviewController {
 
 
     @PostMapping("/recipe/{recipeId}/review/add")
-    public ResponseEntity<?> postReview(
-            Account owner,
+    public ResponseEntity<?> postReviewPage(
+            Account user,
             @PathVariable Long recipeId,
             @RequestBody ReviewPostDto reviewDto ) {
 
         //Test account
 
-        owner.setId(2L);
-        owner.setName("와드");
-        owner.setBio("와드입니다.");
-        owner.setEmail("ward@ward.run");
-        owner.setRole(Role.USER);
-        Account testOwner = testAccountService.save(owner);
+        user.setId(2L);
+        user.setName("와드");
+        user.setBio("와드입니다.");
+        user.setEmail("ward@ward.run");
+        user.setRole(Role.USER);
+
+        user = testAccountService.save(user);
 
         recipeService.verifyExistsId(recipeId); //recipeId가 없을 경우 예외처리
 
-        Review review = reviewMapper.toEntity(reviewDto, testOwner, recipeService.findById(recipeId));
+        Review review = reviewMapper.toEntity(reviewDto, user, recipeService.findById(recipeId));
         reviewService.save(review);
         recipeService.updateStars(recipeId);
 
@@ -58,8 +59,37 @@ public class ReviewController {
                 .data(responseDtoList)
                 .build();
 
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 
-        return new ResponseEntity(responseDto, HttpStatus.OK);
+    @DeleteMapping("/recipe/{recipeId}/review/{reviewId}/delete")
+    public ResponseEntity<?> deleteReviewPage(
+            Account user,
+            @PathVariable Long recipeId,
+            @PathVariable Long reviewId) {
+
+        //Test account
+
+        user.setId(2L);
+        user.setName("와드");
+        user.setBio("와드입니다.");
+        user.setEmail("ward@ward.run");
+        user.setRole(Role.USER);
+
+        user = testAccountService.save(user);
+
+        recipeService.verifyExistsId(recipeId); //recipe 가 없을 경우 예외처리
+        reviewService.verifyAccessOwner(reviewId, user.getId()); //review 가 없을 경우 예외처리
+
+        reviewService.deleteById(reviewId);
+
+        List<ReviewResponseDto> responseDtoList = reviewMapper.toResponseDto(reviewService.findAllByRecipeId(recipeId));
+
+        ResponseDto.Single<?> responseDto = ResponseDto.Single.builder()
+                .data(responseDtoList)
+                .build();
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
 }

--- a/server/src/main/resources/application-image2.properties
+++ b/server/src/main/resources/application-image2.properties
@@ -1,0 +1,4 @@
+
+file.path=/app/client/build/assets/
+
+image.defailt.path=/

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-spring.profiles.include=db2,image,oauth
+spring.profiles.include=db,image,oauth
 spring.pid.file=/home/ward/app/server/mmzproject.pid


### PR DESCRIPTION
## 1. 작업 내용
feat: patchDto, mapper 작성 및 #31
feat: recipe, tag 리스트 get 메소드 생성(DB 조회 -> 영속성 컨텍스트 조회) #31
feat: 예외처리 필요 부분 체크 #31
feat: logback service 추가 #31
feat: 필드 무한 참조 오류 해결 #31
feat: 예외처리 handler 및 전역 오류 컨트롤러 생성 #31
feat: 예외처리 서비스단 추가 #31
feat: response dto 어노테이션 변경 #31
feat: patch dto, mapper 추가 #31
feat: response에 유저 정보 추가 #31
feat: account dto, mapper 추가 #31
feat: 북마크 및 리뷰 엔티티 연관관계 설정 #31
feat: account service 추가 #31
feat: 레시피 검색 및 정렬 sort 추가 #31
feat : 북마크 기능 추가 #31
feat : 북마크 순환참조 에러 수정 #31
feat : 북마크 기능 완성, 예외처리 #31
feat : 레시피, 리뷰 삭제 및 작성자 예외처리 추가 #31
feat : 리뷰만 삭제해도 레시피까지 사라지는 버그 수정 #31

## 2. 주의 사항
-
