### PR TITLE
[FE] 메인 페이지 기능 구현

### DIFF
--- a/client/src/components/Main/Category/CategoryIcon.tsx
+++ b/client/src/components/Main/Category/CategoryIcon.tsx
@@ -35,11 +35,17 @@ interface IconProps {
   alt: string;
   text: string;
   link: string;
+  clickEvent: (categoryValue: string) => void;
 }
 
-const CategoryIcon = ({ img, alt, text, link }: IconProps) => {
+const CategoryIcon = ({ img, alt, text, link, clickEvent }: IconProps) => {
   return (
-    <SIconLayout>
+    <SIconLayout
+      onClick={(e) => {
+        e.preventDefault();
+        clickEvent?.(text);
+      }}
+    >
       <SIconLink to={link}>
         <SImage src={img} alt={alt} />
       </SIconLink>

--- a/client/src/components/Main/Category/CategoryIcon.tsx
+++ b/client/src/components/Main/Category/CategoryIcon.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { IIconProps } from "../../../types/interface";
 
 const SIconLayout = styled.li`
   display: flex;
@@ -30,15 +31,7 @@ const SIconText = styled.span`
   margin: 1rem 0;
 `;
 
-interface IconProps {
-  img: string;
-  alt: string;
-  text: string;
-  link: string;
-  clickEvent: (categoryValue: string) => void;
-}
-
-const CategoryIcon = ({ img, alt, text, link, clickEvent }: IconProps) => {
+const CategoryIcon = ({ img, alt, text, link, clickEvent }: IIconProps) => {
   return (
     <SIconLayout
       onClick={(e) => {

--- a/client/src/components/Main/Category/RecipeCategory.tsx
+++ b/client/src/components/Main/Category/RecipeCategory.tsx
@@ -5,6 +5,7 @@ import pan from "../../../assets/icons/pot.svg";
 import noodle from "../../../assets/icons/noodles.svg";
 import bread from "../../../assets/icons/bread.svg";
 import CategoryIcon from "./CategoryIcon";
+import { ICategoryProps } from "../../../types/interface";
 
 const SCategoryLayout = styled.div`
   display: flex;
@@ -28,25 +29,30 @@ const SCategoryList = styled.ul`
 `;
 
 const categories = [
-  { id: 1, img: mainDish, alt: "메인", text: "메인", link: "/" },
-  { id: 2, img: rice, alt: "밥", text: "밥", link: "/" },
-  { id: 3, img: pan, alt: "국/탕", text: "국/탕", link: "/" },
-  { id: 4, img: noodle, alt: "면", text: "면", link: "/" },
-  { id: 5, img: bread, alt: "빵", text: "빵", link: "/" },
+  { id: 1, img: rice, alt: "밥", text: "밥", link: "/" },
+  { id: 2, img: noodle, alt: "면", text: "면", link: "/" },
+  { id: 3, img: bread, alt: "디저트", text: "디저트", link: "/" },
+  { id: 4, img: mainDish, alt: "음료", text: "음료", link: "/" },
+  { id: 5, img: pan, alt: "기타", text: "기타", link: "/" },
 ];
 
-const RecipeCategory = () => {
+const RecipeCategory = ({ setCategory }: ICategoryProps) => {
+  const onCategoryClick = (categoryValue: string) => {
+    setCategory(categoryValue);
+  };
+
   return (
     <SCategoryLayout>
       <SH1>레시피 분류</SH1>
       <SCategoryList>
-        {categories.map((i) => (
+        {categories.map((i, idx) => (
           <CategoryIcon
-            key={i.id}
+            key={idx}
             img={i.img}
             alt={i.alt}
             text={i.text}
             link={i.link}
+            clickEvent={onCategoryClick}
           />
         ))}
       </SCategoryList>

--- a/client/src/components/Main/RecipeItem/RecipeItemList.tsx
+++ b/client/src/components/Main/RecipeItem/RecipeItemList.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import RecipeItem from "./RecipeItem";
-import { ISearchDataProps } from "../../../types/interface";
+import { IRecipeDataProps } from "../../../types/interface";
 
 const SItemListLayout = styled.div`
   display: grid;
@@ -15,9 +15,20 @@ const SItemListLayout = styled.div`
   }
 `;
 
-const RecipeItemList = ({ searchData }: ISearchDataProps) => {
+const RecipeItemList = ({ mainData, searchData }: IRecipeDataProps) => {
   return (
     <SItemListLayout>
+      {mainData &&
+        mainData.map((i) => (
+          <RecipeItem
+            key={i.id}
+            id={i.id}
+            title={i.title}
+            imgThumbNailUrl={i.imgThumbNailUrl}
+            tags={i.tags}
+            stars={i.stars}
+          />
+        ))}
       {searchData &&
         searchData.map((i) => (
           <RecipeItem

--- a/client/src/components/Search/SearchResultList.tsx
+++ b/client/src/components/Search/SearchResultList.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { SortButtons } from "../CommonUI";
 import { RecipeItemList } from "../Main";
-import { ISearchDataProps } from "../../types/interface";
+import { IRecipeDataProps } from "../../types/interface";
 
 const SSortArea = styled.div`
   display: flex;
@@ -16,7 +16,7 @@ const SResultTitle = styled.div`
 const SearchResultList = ({
   searchData,
   setSearchSortBy,
-}: ISearchDataProps) => {
+}: IRecipeDataProps) => {
   const onSortClick = (sortValue: string) => {
     if (sortValue === "최신순") {
       setSearchSortBy && setSearchSortBy("id");

--- a/client/src/pages/Main/Main.tsx
+++ b/client/src/pages/Main/Main.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { SortButtons } from "../../components/CommonUI";
 import {
@@ -6,6 +7,7 @@ import {
   RecipeCategory,
   RecipeItemList,
 } from "../../components/Main";
+import axios from "axios";
 
 const SMainLayout = styled.main`
   display: flex;
@@ -24,14 +26,48 @@ const SSectionLayout = styled.section`
 
 const Main = () => {
   const sortValues = ["최신순", "조회순", "평점순"];
+  const [mainData, setMainData] = useState<any[]>([]);
+  const [mainSortBy, setMainSortBy] = useState("id");
+  const [category, setCategory] = useState("");
+
+  const axiosMainData = async (mainSortBy: string) => {
+    // 카테고리 미선택 시 전체 데이터 조회
+    if (category === "") {
+      const { data } = await axios.get(
+        `/api/v1/recipe/all/1?orderBy=${mainSortBy}&sort=dec`
+      );
+
+      setMainData(data.data);
+    } else {
+      const { data } = await axios.get(
+        `/api/v1/recipe/category/1?category=${category}&orderBy=${mainSortBy}`
+      );
+
+      setMainData(data.data);
+    }
+  };
+
+  useEffect(() => {
+    axiosMainData(mainSortBy);
+  }, [category, mainSortBy]);
+
+  const onSortClick = (sortValue: string) => {
+    if (sortValue === "최신순") {
+      setMainSortBy("id");
+    } else if (sortValue === "조회순") {
+      setMainSortBy("views");
+    } else if (sortValue === "평점순") {
+      setMainSortBy("stars");
+    }
+  };
 
   return (
     <SMainLayout>
       <Carousel />
       <SSectionLayout>
-        <RecipeCategory />
-        <SortButtons sortValues={sortValues} />
-        <RecipeItemList />
+        <RecipeCategory setCategory={setCategory} />
+        <SortButtons sortValues={sortValues} clickEvent={onSortClick} />
+        <RecipeItemList mainData={mainData} />
       </SSectionLayout>
     </SMainLayout>
   );

--- a/client/src/types/interface.ts
+++ b/client/src/types/interface.ts
@@ -77,6 +77,14 @@ interface ICategoryProps {
   setCategory: React.Dispatch<React.SetStateAction<string>>;
 }
 
+interface IIconProps {
+  img: string;
+  alt: string;
+  text: string;
+  link: string;
+  clickEvent: (categoryValue: string) => void;
+}
+
 export type {
   IImgUploaderProps,
   IStepMakerProps,
@@ -89,4 +97,5 @@ export type {
   ITagProps,
   IRecipeDataProps,
   ICategoryProps,
+  IIconProps,
 };

--- a/client/src/types/interface.ts
+++ b/client/src/types/interface.ts
@@ -48,7 +48,8 @@ interface IItemProps {
   tags: ITagProps[];
 }
 
-interface ISearchDataProps {
+interface IRecipeDataProps {
+  mainData?: IItemProps[];
   searchData?: IItemProps[];
   setSearchSortBy?: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -72,6 +73,10 @@ interface ITagsMakerProps {
   setTagsDatas: Dispatch<SetStateAction<TypeOfTags[]>>;
 }
 
+interface ICategoryProps {
+  setCategory: React.Dispatch<React.SetStateAction<string>>;
+}
+
 export type {
   IImgUploaderProps,
   IStepMakerProps,
@@ -82,5 +87,6 @@ export type {
   ITagsMakerProps,
   IItemProps,
   ITagProps,
-  ISearchDataProps,
+  IRecipeDataProps,
+  ICategoryProps,
 };


### PR DESCRIPTION
## 1. 작업 내용
![image](https://user-images.githubusercontent.com/59650985/193221926-e0a104ac-f376-4708-b26f-0bd39c645e1e.png)
- 메인 페이지 레시피 아이템 데이터 렌더링
- 레시피 카테고리 기능 적용
- 최신순, 조회순, 평점순 정렬 기능 적용

## 2. 전달 사항
- 현재 간단한 테스트를 한 상태이며, 추후 카테고리 별 더미 데이터가 많이 쌓이면 한 번 더 테스트 할 예정입니다.
- 디자인 픽스 된 후 카테고리 이미지 변경 예정입니다.
