### PR TITLE
[FE] 수정페이지 누락값 체크 및 로딩 컴포넌트 수정

### DIFF
--- a/client/src/components/CommonUI/Loading.tsx
+++ b/client/src/components/CommonUI/Loading.tsx
@@ -2,11 +2,22 @@ import styled from "styled-components";
 import logo from "../../assets/logos/logo_move2.gif";
 
 const LogingLayout = styled.div`
-  width: 300px;
-  margin-top: 100px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
-const Spinner = styled.img``;
+const Spinner = styled.img`
+  width: 300px;
+  margin-top: 100px;
+  @media ${({ theme }) => theme.device.tablet} {
+    width: 35%;
+  }
+  @media ${({ theme }) => theme.device.mobile} {
+    width: 50%;
+  }
+`;
 
 const Loading = () => {
   return (

--- a/client/src/components/NewRecipe/AddingIngredients.tsx
+++ b/client/src/components/NewRecipe/AddingIngredients.tsx
@@ -12,7 +12,7 @@ const AddIngredients = ({
   setIngredientsDatas,
 }: IAddIngredientsProps) => {
   const basicForm = {
-    index: 0,
+    index: 1,
     name: "",
     amount: "",
     isEssential: false,

--- a/client/src/components/NewRecipe/ImgUploader.tsx
+++ b/client/src/components/NewRecipe/ImgUploader.tsx
@@ -32,8 +32,6 @@ const ImgUploader = ({
   setStepImgFiles,
   stepImgFiles,
   setImgName,
-  setBooleanArr,
-  booleanArr,
 }: IImgUploaderProps) => {
   const [fileURL, setFileURL] = useState<string>("");
   const imgUploadInput = useRef<HTMLInputElement | null>(null);
@@ -44,25 +42,17 @@ const ImgUploader = ({
         currentIndex !== undefined &&
         stepImgFiles &&
         setStepImgFiles &&
-        setImgName &&
-        setBooleanArr &&
-        booleanArr !== undefined
+        setImgName
       ) {
         const newImgFile = stepImgFiles.slice();
-        const newBooleanList = booleanArr.slice();
         newImgFile[currentIndex] = event.target.files[0];
-        newBooleanList[currentIndex] = true;
 
         console.log("값 전체", newImgFile);
-        // console.log("파일이름", event.target.files[0]);
         setStepImgFiles(newImgFile);
         setImgName(event.target.files[0].name);
-        setBooleanArr(newBooleanList);
       }
       const newFileURL = URL.createObjectURL(event.target.files[0]);
       setFileURL(newFileURL);
-      // console.log("event.target.files", event.target.files);
-      // console.log("file", file);
     }
   };
 

--- a/client/src/components/NewRecipe/StepSet.tsx
+++ b/client/src/components/NewRecipe/StepSet.tsx
@@ -53,13 +53,15 @@ const StepSet = ({
     const originData = directDatas.slice();
     if (originData[currentIndex].imgDirectionUrl !== undefined) {
       originData[currentIndex].imgDirectionUrl = imgName;
-      originData[currentIndex].isUpdated = true;
+      originData[currentIndex].isUploaded = true;
+      originData[currentIndex].index = currentIndex + 1;
       setDirectDatas(originData);
     }
     // 수정 없을 때
     if (!originData[currentIndex].imgDirectionUrl) {
       originData[currentIndex].imgDirectionUrl = imgUrl;
-      originData[currentIndex].isUpdated = false;
+      originData[currentIndex].isUploaded = false;
+      originData[currentIndex].index = currentIndex + 1;
       setDirectDatas(originData);
     }
   }, [imgName]);

--- a/client/src/components/NewRecipe/StepSet.tsx
+++ b/client/src/components/NewRecipe/StepSet.tsx
@@ -26,8 +26,6 @@ const StepSet = ({
   imgUrl,
   directDatas,
   setDirectDatas,
-  booleanArr,
-  setBooleanArr,
 }: IStepSetProps) => {
   const [imgName, setImgName] = useState<string>("");
   const currentIndex = directDatas.findIndex((step) => {
@@ -55,10 +53,13 @@ const StepSet = ({
     const originData = directDatas.slice();
     if (originData[currentIndex].imgDirectionUrl !== undefined) {
       originData[currentIndex].imgDirectionUrl = imgName;
+      originData[currentIndex].isUpdated = true;
       setDirectDatas(originData);
     }
+    // 수정 없을 때
     if (!originData[currentIndex].imgDirectionUrl) {
       originData[currentIndex].imgDirectionUrl = imgUrl;
+      originData[currentIndex].isUpdated = false;
       setDirectDatas(originData);
     }
   }, [imgName]);
@@ -88,10 +89,9 @@ const StepSet = ({
         stepImgFiles={stepImgFiles}
         setStepImgFiles={setStepImgFiles}
         setImgName={setImgName}
-        booleanArr={booleanArr}
-        setBooleanArr={setBooleanArr}
       ></ImgUploader>
     </SStepsContainer>
   );
 };
+
 export default StepSet;

--- a/client/src/components/NewRecipe/StepsMaker.tsx
+++ b/client/src/components/NewRecipe/StepsMaker.tsx
@@ -1,5 +1,4 @@
 import { IStepMakerProps } from "../../types/interface";
-import { useEffect } from "react";
 import { StepSet, PlusBtn } from "./indexNewRecipe";
 
 const StepsMaker = ({
@@ -12,7 +11,7 @@ const StepsMaker = ({
     index: 1,
     imgDirectionUrl: "",
     body: "",
-    isUpdated: false,
+    isUploaded: false,
   };
 
   // let initialValue;
@@ -54,6 +53,7 @@ const StepsMaker = ({
   //   console.log("요소", editResponse.directions);
   //   // });
   // }
+
   const addDirectionsHander = () => {
     const lastStep = directDatas.slice(-1)[0];
     if (lastStep) {

--- a/client/src/components/NewRecipe/StepsMaker.tsx
+++ b/client/src/components/NewRecipe/StepsMaker.tsx
@@ -7,13 +7,12 @@ const StepsMaker = ({
   setDirectDatas,
   stepImgFiles,
   setStepImgFiles,
-  booleanArr,
-  setBooleanArr,
 }: IStepMakerProps) => {
   const basicForm = {
     index: 1,
     imgDirectionUrl: "",
     body: "",
+    isUpdated: false,
   };
 
   // let initialValue;
@@ -46,7 +45,6 @@ const StepsMaker = ({
   //     basicForm.index = lastStep.index + 1;
   //   }
   //   setSteps([...steps, basicForm]);
-  //   setBooleanArr([...booleanArr, false]);
 
   // const initialValue = resDirecttions ? resDirecttions : [basicForm];
   // console.log("directDatas", directDatas);
@@ -62,15 +60,7 @@ const StepsMaker = ({
       basicForm.index = lastStep.index + 1;
     }
     setDirectDatas([...directDatas, basicForm]);
-    setBooleanArr([...booleanArr, false]);
   };
-
-  useEffect(() => {
-    // console.log("resDirecttions", editResponse);
-    // if (resDirecttions) {
-    //   setSteps(resDirecttions);
-    // }
-  }, [directDatas]);
 
   return (
     <>
@@ -88,8 +78,6 @@ const StepsMaker = ({
                 setStepImgFiles={setStepImgFiles}
                 directDatas={directDatas}
                 setDirectDatas={setDirectDatas}
-                booleanArr={booleanArr}
-                setBooleanArr={setBooleanArr}
               />
             );
           })}

--- a/client/src/hooks/useRecipeValidation.tsx
+++ b/client/src/hooks/useRecipeValidation.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect } from "react";
+import {
+  IStepValues,
+  ITagProps,
+  IPostInGredientProps,
+} from "../types/interface";
+import { TypeOfIngredients, TypeOfTags } from "../types/type";
+
+const useRecipeValidation = (
+  data: { body: string; title: string },
+  ingredientsDatas: TypeOfIngredients[],
+  directDatas: IStepValues[],
+  tagsDatas: TypeOfTags[]
+): boolean => {
+  const [isEmpty, setIsEmpty] = useState<boolean>(false);
+  // console.log("유즈 isEmpty", isEmpty);
+  // console.log("유즈 data", data);
+  // console.log("유즈 재료", ingredientsDatas);
+  // console.log("유즈 순서", directDatas);
+  // console.log("유즈 태그", tagsDatas);
+
+  useEffect(() => {
+    setIsEmpty(false);
+
+    if (!data.body || !data.title) {
+      // console.log(data.body, data.title);
+      setIsEmpty(true);
+    }
+
+    ingredientsDatas.forEach((ingredient: IPostInGredientProps) => {
+      if (!ingredient.amount || !ingredient.name) {
+        // console.log(ingredient.amount, ingredient.name);
+        setIsEmpty(true);
+      }
+    });
+
+    directDatas.forEach((directInfo: IStepValues) => {
+      if (!directInfo.body) {
+        // console.log(directInfo.body);
+        setIsEmpty(true);
+      }
+    });
+
+    tagsDatas.forEach((tag: ITagProps) => {
+      if (!tag.name) {
+        // console.log(tag.name);
+        setIsEmpty(true);
+      }
+    });
+  }, [data, ingredientsDatas, directDatas, tagsDatas]);
+
+  return isEmpty;
+};
+
+export default useRecipeValidation;

--- a/client/src/pages/Recipe/AddPost.tsx
+++ b/client/src/pages/Recipe/AddPost.tsx
@@ -118,7 +118,6 @@ const AddPost = () => {
   // 등록페이지 관련
   const [thumbNail, setThumbNail] = useState<TypeOfFileList>();
   const [stepImgFiles, setStepImgFiles] = useState<TypeOfFileList[]>([]);
-  const [booleanArr, setBooleanArr] = useState<boolean[]>([]);
   const [directDatas, setDirectDatas] = useState<IStepValues[]>([]);
   const [checkedCateg, setCheckedCateg] = useState("");
   const [ingredientsDatas, setIngredientsDatas] = useState<TypeOfIngredients[]>(
@@ -132,9 +131,8 @@ const AddPost = () => {
     // formState: { errors },
   } = useForm<TypeOfFormData>(undefined);
 
-  // console.log("불리언", booleanArr);
-  // console.log("재료", ingredientsDatas);
   const submitHandler: SubmitHandler<TypeOfFormData> = async (data) => {
+    // console.log("재료", ingredientsDatas);
     // console.log("onSubmitData", data);
     // console.log("d이미지 순서", stepImgFiles);
     // console.log("순서", directDatas);
@@ -197,7 +195,7 @@ const AddPost = () => {
     }
   };
 
-  // console.log(editResponse);
+  console.log("directDatas", directDatas);
 
   return (
     <SFormContainer>
@@ -258,8 +256,6 @@ const AddPost = () => {
             <Guide text="중요한 부분은 빠짐없이 적어주세요." />
           </SLable>
           <StepsMaker
-            booleanArr={booleanArr}
-            setBooleanArr={setBooleanArr}
             directDatas={directDatas}
             setDirectDatas={setDirectDatas}
             stepImgFiles={stepImgFiles}

--- a/client/src/pages/Recipe/AddPost.tsx
+++ b/client/src/pages/Recipe/AddPost.tsx
@@ -179,10 +179,11 @@ const AddPost = () => {
     );
 
     /** 서버 요청 */
+    const response = await axios.post("/api/v1/recipe/add", formData, {
+      headers: { "content-type": "multipart/form-data" },
+    });
+
     try {
-      const response = await axios.post("/api/v1/recipe/add", formData, {
-        headers: { "content-type": "multipart/form-data" },
-      });
       const newId = response.data.data.id;
       navigate(`/post/${newId}/`);
     } catch (error) {

--- a/client/src/pages/Recipe/EditPost.tsx
+++ b/client/src/pages/Recipe/EditPost.tsx
@@ -13,16 +13,13 @@ import {
   ImgRadio,
   RequireMark,
 } from "../../components/NewRecipe/indexNewRecipe";
-import {
-  TypeOfFileList,
-  TypeOfFormData,
-  TypeOfIngredients,
-} from "../../types/type";
+import { TypeOfFileList, TypeOfIngredients } from "../../types/type";
 import {
   IStepValues,
   ITagsData,
   ITagProps,
   IEditResponseData,
+  IPostInGredientProps,
   IRecipeTemp,
 } from "../../types/interface";
 import { useState, useEffect } from "react";
@@ -130,7 +127,6 @@ const EditPost = () => {
   const [thumbNailUrl, setThumbNailUrl] = useState<string>();
   const [thumbNail, setThumbNail] = useState<TypeOfFileList>();
   const [stepImgFiles, setStepImgFiles] = useState<TypeOfFileList[]>([]);
-  const [booleanArr, setBooleanArr] = useState<boolean[]>([]);
   const [directDatas, setDirectDatas] = useState<IStepValues[]>([]);
   const [checkedCateg, setCheckedCateg] = useState("");
   const [ingredientsDatas, setIngredientsDatas] = useState<TypeOfIngredients[]>(
@@ -164,22 +160,35 @@ const EditPost = () => {
     // console.log("불리언", booleanArr);
     // console.log("d이미지 순서", stepImgFiles);
 
+    // if (!data.body || !data.title) {
+    //   setIsEmpty(true);
+    //   // return true;
+    // }
+
+    // ingredientsDatas.forEach((ingredient: IPostInGredientProps) => {
+    //   if (!ingredient.amount || !ingredient.name) {
+    //     setIsEmpty(true);
+    //     // return true;
+    //   }
+    // });
+
+    // directDatas.forEach((directInfo: IStepValues) => {
+    //   if (!directInfo.body) {
+    //     setIsEmpty(true);
+    //     // return true;
+    //   }
+    // });
+
+    // tagsDatas.forEach((tag: ITagProps) => {
+    //   // console.log(tag);
+    //   if (!tag.name) {
+    //     setIsEmpty(true);
+    //     // return true;
+    //   }
+    // });
+
     // console.log("setIsEmpty", isEmpty);
 
-    // if (isEmpty) {
-    //   // console.log("빈 조건문", isEmpty);
-    //   message.fire({
-    //     icon: "error",
-    //     title:
-    //       "레시피 등록에 실패했습니다.\n 누락된 정보가 있는지 \n확인해주세요.",
-    //   });
-    //   // setIsEmpty(() => false);
-    //   return;
-    // }
-    // if()
-    // else {
-    //   setIsEmpty(true);
-    // }
     /** 서버 요청 데이터 구축 */
     const formData = new FormData();
 
@@ -193,16 +202,6 @@ const EditPost = () => {
       }
     });
 
-    booleanArr.forEach((el, idx) => {
-      const newFile = new File([], "temp.mmz");
-      if (stepImgFiles[idx]) {
-        // console.log("타입", typeof stepImgFiles[idx]);
-        // formData.append("imgDirection", stepImgFiles[idx]);
-      } else {
-        console.log("빈값", newFile);
-        // formData.append("imgDirection", newFile);
-      }
-    });
     const recipeDatas = {
       ...data,
       category: checkedCateg,
@@ -210,6 +209,7 @@ const EditPost = () => {
       directions: directDatas,
       tags: tagsDatas,
     };
+    console.log("수정페이지recipeDatas", recipeDatas);
 
     formData.append(
       "recipe",
@@ -217,28 +217,28 @@ const EditPost = () => {
     );
 
     /** 서버 요청 */
-    if (!isEmpty) {
-      const response = await axios.post(`/recipe/{recipeId}/edit`, formData, {
-        headers: { "content-type": "multipart/form-data" },
-      });
-      try {
-        // if(respones.status ===200){}
-        const newId = response.data.data.id;
-        navigate(`/post/${newId}/`);
-      } catch (error) {
-        console.log(error);
-        message.fire({
-          icon: "error",
-          title: "레시피 등록에 실패했습니다.\n 다시 시도해주세요.",
-        });
-      }
-    } else {
-      message.fire({
-        icon: "error",
-        title:
-          "레시피 등록에 실패했습니다.\n 누락된 정보가 있는지 \n확인해주세요.",
-      });
-    }
+    // if (!isEmpty) {
+    //   const response = await axios.post(`/recipe/{recipeId}/edit`, formData, {
+    //     headers: { "content-type": "multipart/form-data" },
+    //   });
+    //   try {
+    //     // if(respones.status ===200){}
+    //     const newId = response.data.data.id;
+    //     navigate(`/post/${newId}/`);
+    //   } catch (error) {
+    //     console.log(error);
+    //     message.fire({
+    //       icon: "error",
+    //       title: "레시피 등록에 실패했습니다.\n 다시 시도해주세요.",
+    //     });
+    //   }
+    // } else {
+    //   message.fire({
+    //     icon: "error",
+    //     title:
+    //       "레시피 등록에 실패했습니다.\n 누락된 정보가 있는지 \n확인해주세요.",
+    //   });
+    // }
   };
 
   useEffect(() => {
@@ -261,6 +261,8 @@ const EditPost = () => {
         console.log("수정에러", err);
       });
   }, []);
+  console.log("수정페이지 순서", directDatas);
+
   // console.log(data, "data");
 
   return (
@@ -338,8 +340,6 @@ const EditPost = () => {
             <Guide text="중요한 부분은 빠짐없이 적어주세요." />
           </SLable>
           <StepsMaker
-            booleanArr={booleanArr}
-            setBooleanArr={setBooleanArr}
             directDatas={directDatas}
             setDirectDatas={setDirectDatas}
             stepImgFiles={stepImgFiles}

--- a/client/src/pages/Recipe/EditPost.tsx
+++ b/client/src/pages/Recipe/EditPost.tsx
@@ -18,14 +18,14 @@ import {
   IStepValues,
   ITagsData,
   ITagProps,
-  IEditResponseData,
-  IPostInGredientProps,
+  // IEditResponseData,
+  // IPostInGredientProps,
   IRecipeTemp,
 } from "../../types/interface";
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import axios from "axios";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import recipeLogo from "../../assets/images/Recipe/recipeLogo.svg";
 import useMessage from "../../hooks/useMessage";
 import useRecipeValidation from "../../hooks/useRecipeValidation";
@@ -116,7 +116,7 @@ const SFormBtn = styled.button`
 
 const EditPost = () => {
   const message = useMessage(3000);
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
   // 수정페이지 관련
   const { recipeId } = useParams();
@@ -173,6 +173,12 @@ const EditPost = () => {
 
     if (thumbNail) {
       formData.append("imgThumbNail", thumbNail);
+    } else {
+      // 썸네일 수정 없을 때 임시 파일 전송(테스트 중)
+      const tempFile = new File(["foo"], "foo.txt", {
+        type: "text/plain",
+      });
+      formData.append("imgThumbNail", tempFile);
     }
 
     stepImgFiles.forEach((file) => {

--- a/client/src/pages/Recipe/EditPost.tsx
+++ b/client/src/pages/Recipe/EditPost.tsx
@@ -28,7 +28,7 @@ import axios from "axios";
 import { useParams, useNavigate } from "react-router-dom";
 import recipeLogo from "../../assets/images/Recipe/recipeLogo.svg";
 import useMessage from "../../hooks/useMessage";
-// import useRecipeValidation from "../../hooks/useRecipeValidation";
+import useRecipeValidation from "../../hooks/useRecipeValidation";
 
 const SFormContainer = styled.main`
   max-width: 1280px;
@@ -133,15 +133,14 @@ const EditPost = () => {
     []
   );
   const [tagsDatas, setTagsDatas] = useState<ITagsData[]>([]);
-  const [isEmpty, setIsEmpty] = useState<boolean>(false);
 
   // 빈 값 체크
-  // const isEmpty = useRecipeValidation(
-  //   data,
-  //   ingredientsDatas,
-  //   directDatas,
-  //   tagsDatas
-  // );
+  const isEmpty = useRecipeValidation(
+    data,
+    ingredientsDatas,
+    directDatas,
+    tagsDatas
+  );
 
   const inputHandler = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -151,6 +150,14 @@ const EditPost = () => {
   };
 
   const submitHandler = async () => {
+    if (isEmpty === true) {
+      message.fire({
+        icon: "error",
+        title:
+          "레시피 등록에 실패했습니다.\n 누락된 정보가 있는지 \n확인해주세요.",
+      });
+      return;
+    }
     // console.log(isEmpty);
     // console.log("카테", checkedCateg); // 수정시 null X
     // console.log("onSubmitData", data);
@@ -159,34 +166,6 @@ const EditPost = () => {
     // console.log("태그", tagsDatas);
     // console.log("불리언", booleanArr);
     // console.log("d이미지 순서", stepImgFiles);
-
-    // if (!data.body || !data.title) {
-    //   setIsEmpty(true);
-    //   // return true;
-    // }
-
-    // ingredientsDatas.forEach((ingredient: IPostInGredientProps) => {
-    //   if (!ingredient.amount || !ingredient.name) {
-    //     setIsEmpty(true);
-    //     // return true;
-    //   }
-    // });
-
-    // directDatas.forEach((directInfo: IStepValues) => {
-    //   if (!directInfo.body) {
-    //     setIsEmpty(true);
-    //     // return true;
-    //   }
-    // });
-
-    // tagsDatas.forEach((tag: ITagProps) => {
-    //   // console.log(tag);
-    //   if (!tag.name) {
-    //     setIsEmpty(true);
-    //     // return true;
-    //   }
-    // });
-
     // console.log("setIsEmpty", isEmpty);
 
     /** 서버 요청 데이터 구축 */
@@ -209,36 +188,39 @@ const EditPost = () => {
       directions: directDatas,
       tags: tagsDatas,
     };
-    console.log("수정페이지recipeDatas", recipeDatas);
 
     formData.append(
       "recipe",
       new Blob([JSON.stringify(recipeDatas)], { type: "application/json" })
     );
 
+    // console.log("수정페이지 버튼 recipeDatas", recipeDatas);
+    // console.log(formData.get("recipe"));
+
     /** 서버 요청 */
-    // if (!isEmpty) {
-    //   const response = await axios.post(`/recipe/{recipeId}/edit`, formData, {
-    //     headers: { "content-type": "multipart/form-data" },
-    //   });
-    //   try {
-    //     // if(respones.status ===200){}
-    //     const newId = response.data.data.id;
-    //     navigate(`/post/${newId}/`);
-    //   } catch (error) {
-    //     console.log(error);
-    //     message.fire({
-    //       icon: "error",
-    //       title: "레시피 등록에 실패했습니다.\n 다시 시도해주세요.",
-    //     });
-    //   }
-    // } else {
-    //   message.fire({
-    //     icon: "error",
-    //     title:
-    //       "레시피 등록에 실패했습니다.\n 누락된 정보가 있는지 \n확인해주세요.",
-    //   });
-    // }
+    const response = await axios.post(
+      `/api/v1/recipe/${recipeId}/edit`,
+      formData,
+      {
+        headers: { "content-type": "multipart/form-data" },
+      }
+    );
+
+    try {
+      console.log(response);
+
+      // if(respones.status ===200){
+
+      // }
+      // const newId = response.data.data.id;
+      // navigate(`/post/${newId}/`);
+    } catch (error) {
+      console.log(error);
+      message.fire({
+        icon: "error",
+        title: "레시피 등록에 실패했습니다.\n 다시 시도해주세요.",
+      });
+    }
   };
 
   useEffect(() => {
@@ -246,6 +228,7 @@ const EditPost = () => {
       .get(`/api/v1/recipe/${recipeId}/edit/`)
       .then((res) => {
         const resData = res.data.data;
+        // console.log("resData", resData);
         setData({ body: resData.body, title: resData.title });
         setCheckedCateg(resData.category);
         setDirectDatas(resData.directions);
@@ -261,9 +244,7 @@ const EditPost = () => {
         console.log("수정에러", err);
       });
   }, []);
-  console.log("수정페이지 순서", directDatas);
-
-  // console.log(data, "data");
+  console.log("순서", directDatas);
 
   return (
     <SFormContainer>

--- a/client/src/types/interface.ts
+++ b/client/src/types/interface.ts
@@ -15,8 +15,6 @@ interface IImgUploaderProps {
   stepImgFiles?: TypeOfFileList[];
   setStepImgFiles?: Dispatch<SetStateAction<TypeOfFileList[]>>;
   setImgName?: Dispatch<SetStateAction<string>>;
-  booleanArr: boolean[];
-  setBooleanArr: Dispatch<SetStateAction<boolean[]>>;
 }
 
 interface IStepMakerProps {
@@ -26,8 +24,6 @@ interface IStepMakerProps {
   setDirectDatas: Dispatch<SetStateAction<IStepValues[]>>;
   stepImgFiles: TypeOfFileList[];
   setStepImgFiles: Dispatch<SetStateAction<TypeOfFileList[]>>;
-  setBooleanArr: Dispatch<SetStateAction<boolean[]>>;
-  booleanArr: boolean[];
   // clickEvent?: (orderValue: string) => Promise<void> | void;
 }
 
@@ -35,6 +31,7 @@ interface IStepValues {
   imgDirectionUrl: string;
   body: string;
   index: number;
+  isUpdated: boolean;
 }
 
 interface IStepSetProps {
@@ -46,8 +43,6 @@ interface IStepSetProps {
   setStepImgFiles: Dispatch<SetStateAction<TypeOfFileList[]>>;
   directDatas: IStepValues[];
   setDirectDatas: Dispatch<SetStateAction<IStepValues[]>>;
-  setBooleanArr: Dispatch<SetStateAction<boolean[]>>;
-  booleanArr: boolean[];
 }
 
 interface IResponseImgProps {

--- a/client/src/types/interface.ts
+++ b/client/src/types/interface.ts
@@ -263,6 +263,12 @@ interface IStarProps {
   setStarClicked?: React.Dispatch<React.SetStateAction<boolean[]>>;
 }
 
+// 리펙토링 전 임시 사용
+interface IRecipeTemp {
+  body: string;
+  title: string;
+}
+
 export type {
   IThumbNailProps,
   IImgUploaderProps,
@@ -297,4 +303,5 @@ export type {
   IFollowProps,
   IFollowingProps,
   IStarProps,
+  IRecipeTemp,
 };

--- a/client/src/types/interface.ts
+++ b/client/src/types/interface.ts
@@ -31,7 +31,7 @@ interface IStepValues {
   imgDirectionUrl: string;
   body: string;
   index: number;
-  isUpdated: boolean;
+  isUploaded: boolean;
 }
 
 interface IStepSetProps {


### PR DESCRIPTION
## 1. 작업 내용
- 레시피 수정할 때, 수정된 이미지만 서버에 전달하여 수정 가능하도록 수정
- 누락값이 있을 때 서버 요청을 막고 알림 표시
- 로딩 컴포넌트 반응형으로 사이즈
<img width="305" alt="image" src="https://user-images.githubusercontent.com/90553688/194973183-87993b78-3202-48c3-b2c9-8da28ec47af7.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/90553688/194973292-a6f315b0-74f6-4a92-a3db-f1ed1cde94f0.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/90553688/194973419-730f4dd2-5c22-4c35-ab94-fbbcc69cade5.png">



## 2. 전달사항
- 주석처리된 콘솔과 수정, 등록페이지 리펙토링 진행 예정입니다.
