### PR TITLE
[FE] 레시피 수정페이지 입력칸 제거 후 발생하는 오류 수정,  누락값 체크 보완

### DIFF
--- a/client/src/hooks/useRecipeValidation.tsx
+++ b/client/src/hooks/useRecipeValidation.tsx
@@ -13,40 +13,35 @@ const useRecipeValidation = (
   tagsDatas: TypeOfTags[]
 ): boolean => {
   const [isEmpty, setIsEmpty] = useState<boolean>(false);
-  // console.log("유즈 isEmpty", isEmpty);
-  // console.log("유즈 data", data);
-  // console.log("유즈 재료", ingredientsDatas);
-  // console.log("유즈 순서", directDatas);
-  // console.log("유즈 태그", tagsDatas);
 
   useEffect(() => {
     setIsEmpty(false);
 
     if (!data.body || !data.title) {
-      // console.log(data.body, data.title);
       setIsEmpty(true);
     }
 
     ingredientsDatas.forEach((ingredient: IPostInGredientProps) => {
       if (!ingredient.amount || !ingredient.name) {
-        // console.log(ingredient.amount, ingredient.name);
         setIsEmpty(true);
       }
     });
 
     directDatas.forEach((directInfo: IStepValues) => {
       if (!directInfo.body) {
-        // console.log(directInfo.body);
         setIsEmpty(true);
       }
     });
 
     tagsDatas.forEach((tag: ITagProps) => {
       if (!tag.name) {
-        // console.log(tag.name);
         setIsEmpty(true);
       }
     });
+
+    if (ingredientsDatas.length === 0 || directDatas.length === 0) {
+      setIsEmpty(true);
+    }
   }, [data, ingredientsDatas, directDatas, tagsDatas]);
 
   return isEmpty;

--- a/client/src/pages/Recipe/AddPost.tsx
+++ b/client/src/pages/Recipe/AddPost.tsx
@@ -132,13 +132,6 @@ const AddPost = () => {
   } = useForm<TypeOfFormData>(undefined);
 
   const submitHandler: SubmitHandler<TypeOfFormData> = async (data) => {
-    // console.log("재료", ingredientsDatas);
-    // console.log("onSubmitData", data);
-    // console.log("d이미지 순서", stepImgFiles);
-    // console.log("순서", directDatas);
-    // console.log("태그", tagsDatas);
-    // console.log("카테", checkedCateg);
-
     /** 이미지 누락 체크 */
     const emptyIndex = stepImgFiles.findIndex((el) => el === undefined);
     if (emptyIndex >= 0) {
@@ -187,7 +180,6 @@ const AddPost = () => {
       const newId = response.data.data.id;
       navigate(`/post/${newId}/`);
     } catch (error) {
-      // console.log(error);
       message.fire({
         icon: "error",
         title:
@@ -195,8 +187,6 @@ const AddPost = () => {
       });
     }
   };
-
-  console.log("directDatas", directDatas);
 
   return (
     <SFormContainer>

--- a/client/src/pages/Recipe/EditPost.tsx
+++ b/client/src/pages/Recipe/EditPost.tsx
@@ -158,10 +158,6 @@ const EditPost = () => {
       });
       return;
     }
-    // console.log("카테", checkedCateg); // 수정시 null X
-    // console.log("onSubmitData", data);
-    // console.log("재료", ingredientsDatas);
-    // console.log("순서", directDatas);
 
     /** 서버 요청 데이터 구축 */
     const formdata = new FormData();
@@ -182,11 +178,23 @@ const EditPost = () => {
       }
     });
 
+    // 재료순서 변경 인덱스 정렬
+    const filteredIngredients: TypeOfIngredients[] = [];
+    ingredientsDatas.forEach((oneline, idx) => {
+      filteredIngredients.push({ ...oneline, index: idx + 1 });
+    });
+
+    // 조리순서 변경 인덱스 정렬
+    const filteredDirects: IStepValues[] = [];
+    directDatas.forEach((oneline, idx) => {
+      filteredDirects.push({ ...oneline, index: idx + 1 });
+    });
+
     const recipeDatas = {
       ...data,
       category: checkedCateg,
-      ingredients: ingredientsDatas,
-      directions: directDatas,
+      ingredients: filteredIngredients,
+      directions: filteredDirects,
       tags: tagsDatas,
     };
 
@@ -194,8 +202,6 @@ const EditPost = () => {
       "recipe",
       new Blob([JSON.stringify(recipeDatas)], { type: "application/json" })
     );
-
-    console.log("수정페이지 버튼 recipeDatas", recipeDatas);
 
     /** 서버 요청 */
     const response = await axios.post(
@@ -222,7 +228,6 @@ const EditPost = () => {
       .get(`/api/v1/recipe/${recipeId}/edit/`)
       .then((res) => {
         const resData = res.data.data;
-        // console.log("resData", resData);
         setData({ body: resData.body, title: resData.title });
         setCheckedCateg(resData.category);
         setDirectDatas(resData.directions);
@@ -241,7 +246,6 @@ const EditPost = () => {
         });
       });
   }, []);
-  console.log("순서", directDatas);
 
   return (
     <SFormContainer>

--- a/client/src/pages/Recipe/EditPost.tsx
+++ b/client/src/pages/Recipe/EditPost.tsx
@@ -25,7 +25,7 @@ import {
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import axios from "axios";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import recipeLogo from "../../assets/images/Recipe/recipeLogo.svg";
 import useMessage from "../../hooks/useMessage";
 import useRecipeValidation from "../../hooks/useRecipeValidation";
@@ -116,7 +116,7 @@ const SFormBtn = styled.button`
 
 const EditPost = () => {
   const message = useMessage(3000);
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
 
   // 수정페이지 관련
   const { recipeId } = useParams();
@@ -158,32 +158,27 @@ const EditPost = () => {
       });
       return;
     }
-    // console.log(isEmpty);
     // console.log("카테", checkedCateg); // 수정시 null X
     // console.log("onSubmitData", data);
     // console.log("재료", ingredientsDatas);
     // console.log("순서", directDatas);
-    // console.log("태그", tagsDatas);
-    // console.log("불리언", booleanArr);
-    // console.log("d이미지 순서", stepImgFiles);
-    // console.log("setIsEmpty", isEmpty);
 
     /** 서버 요청 데이터 구축 */
-    const formData = new FormData();
+    const formdata = new FormData();
 
     if (thumbNail) {
-      formData.append("imgThumbNail", thumbNail);
+      formdata.append("imgThumbNail", thumbNail);
     } else {
-      // 썸네일 수정 없을 때 임시 파일 전송(테스트 중)
+      // 썸네일 수정 없을 때 임의의 파일 전송
       const tempFile = new File(["foo"], "foo.txt", {
         type: "text/plain",
       });
-      formData.append("imgThumbNail", tempFile);
+      formdata.append("imgThumbNail", tempFile);
     }
 
     stepImgFiles.forEach((file) => {
       if (file) {
-        formData.append("imgDirection", file);
+        formdata.append("imgDirection", file);
       }
     });
 
@@ -195,33 +190,26 @@ const EditPost = () => {
       tags: tagsDatas,
     };
 
-    formData.append(
+    formdata.append(
       "recipe",
       new Blob([JSON.stringify(recipeDatas)], { type: "application/json" })
     );
 
-    // console.log("수정페이지 버튼 recipeDatas", recipeDatas);
-    // console.log(formData.get("recipe"));
+    console.log("수정페이지 버튼 recipeDatas", recipeDatas);
 
     /** 서버 요청 */
     const response = await axios.post(
       `/api/v1/recipe/${recipeId}/edit`,
-      formData,
+      formdata,
       {
         headers: { "content-type": "multipart/form-data" },
       }
     );
 
     try {
-      console.log(response);
-
-      // if(respones.status ===200){
-
-      // }
-      // const newId = response.data.data.id;
-      // navigate(`/post/${newId}/`);
+      const newId = response.data.data.id;
+      navigate(`/post/${newId}/`);
     } catch (error) {
-      console.log(error);
       message.fire({
         icon: "error",
         title: "레시피 등록에 실패했습니다.\n 다시 시도해주세요.",
@@ -246,8 +234,11 @@ const EditPost = () => {
         });
         setTagsDatas([...tagList]);
       })
-      .catch((err) => {
-        console.log("수정에러", err);
+      .catch(() => {
+        message.fire({
+          icon: "error",
+          title: "서버 에러가 발생했습니다. \n 다시 시도해주세요.",
+        });
       });
   }, []);
   console.log("순서", directDatas);


### PR DESCRIPTION
## 1. 작업 내용
- 재료입력, 요리순서 입력칸의 제거버튼 클릭시 index 데이터로 인해 서버 오류 발생하는 문제 수정
- 누락값 체크시 재료입력과 요리순서가 없는 경우도 필터링 될 수 있도록 수정
- 콘솔로그 제거

