### PR TITLE
[FE] 마이페이지 사용자 프로필 변경 기능 추가

### DIFF
--- a/client/src/components/NewRecipe/ImgUploader.tsx
+++ b/client/src/components/NewRecipe/ImgUploader.tsx
@@ -46,8 +46,6 @@ const ImgUploader = ({
       ) {
         const newImgFile = stepImgFiles.slice();
         newImgFile[currentIndex] = event.target.files[0];
-
-        console.log("값 전체", newImgFile);
         setStepImgFiles(newImgFile);
         setImgName(event.target.files[0].name);
       }

--- a/client/src/components/NewRecipe/StepSet.tsx
+++ b/client/src/components/NewRecipe/StepSet.tsx
@@ -84,7 +84,6 @@ const StepSet = ({
         />
       </SStepBox>
       <ImgUploader
-        // steps={steps}
         imgName={imgName}
         currentIndex={currentIndex}
         imgUrl={imgUrl}

--- a/client/src/components/NewRecipe/StepsMaker.tsx
+++ b/client/src/components/NewRecipe/StepsMaker.tsx
@@ -14,46 +14,6 @@ const StepsMaker = ({
     isUploaded: false,
   };
 
-  // let initialValue;
-  // directDatas === undefined
-  //   ? (initialValue = [basicForm])
-  //   : (initialValue = directDatas);
-  // const [steps, setSteps] = useState<IStepValues[]>(initialValue);
-
-  // console.log(steps);
-
-  // const addDirectionsHander = () => {
-  //   if (setEditResponse && editResponse) {
-  //     const newRes = { ...editResponse };
-  //     console.log("핸들러", newRes);
-  //     if (newRes.directions) {
-  //       const lastStepId = newRes.directions.slice(-1)[0].index;
-  //       newRes.directions.push({
-  //         index: lastStepId + 1,
-  //         imgDirectionUrl: "",
-  //         body: "",
-  //       });
-  //     }
-  //     console.log("newRes", newRes);
-  //     setEditResponse({ ...newRes });
-  //   }
-  // };
-
-  //   const lastStep = steps.slice(-1)[0];
-  //   if (lastStep) {
-  //     basicForm.index = lastStep.index + 1;
-  //   }
-  //   setSteps([...steps, basicForm]);
-
-  // const initialValue = resDirecttions ? resDirecttions : [basicForm];
-  // console.log("directDatas", directDatas);
-  // console.log("steps", steps);
-  // if (editResponse && editResponse.directions) {
-  //   // editResponse.directions((el) => {
-  //   console.log("요소", editResponse.directions);
-  //   // });
-  // }
-
   const addDirectionsHander = () => {
     const lastStep = directDatas.slice(-1)[0];
     if (lastStep) {

--- a/client/src/components/NewRecipe/ThumbNailUploader.tsx
+++ b/client/src/components/NewRecipe/ThumbNailUploader.tsx
@@ -10,6 +10,21 @@ const SImgInputContainer = styled.div`
   flex-direction: column;
 `;
 
+const SUserImg = styled.img`
+  display: inline-block;
+  overflow: hidden;
+  position: relative;
+  box-sizing: border-box;
+  background-color: var(--pale-gray);
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  @media ${({ theme }) => theme.device.mobile} {
+    width: 100px;
+    height: 100px;
+  }
+`;
+
 const SImg = styled.img`
   width: 430px;
   height: 275px;
@@ -28,6 +43,7 @@ const SImgInput = styled.input`
 `;
 
 const ThumbNailUploader = ({
+  isMypage,
   resThumbNailImgUrl,
   setThumbNail,
 }: IThumbNailProps) => {
@@ -46,23 +62,41 @@ const ThumbNailUploader = ({
 
   return (
     <SImgInputContainer>
-      <SLable htmlFor="img">
-        썸네일
-        <RequireMark />
-      </SLable>
-      <SImg
-        src={
-          fileURL !== `${process.env.PUBLIC_URL}/assets/${undefined}`
-            ? fileURL
-            : defaultImg
-        }
-        alt={fileURL ? fileURL.slice(8) : "undefined"}
-        onClick={() => {
-          if (imgUploadInput.current) {
-            imgUploadInput.current.click();
+      {isMypage ? (
+        <SUserImg
+          src={
+            fileURL !== `${process.env.PUBLIC_URL}/assets/${undefined}`
+              ? fileURL
+              : `${process.env.PUBLIC_URL}/assets/${resThumbNailImgUrl}`
           }
-        }}
-      ></SImg>
+          onClick={() => {
+            if (imgUploadInput.current) {
+              imgUploadInput.current.click();
+            }
+          }}
+        ></SUserImg>
+      ) : (
+        <>
+          <SLable htmlFor="img">
+            썸네일
+            <RequireMark />
+          </SLable>
+          <SImg
+            src={
+              fileURL !== `${process.env.PUBLIC_URL}/assets/${undefined}`
+                ? fileURL
+                : defaultImg
+            }
+            alt={fileURL ? fileURL.slice(8) : "undefined"}
+            onClick={() => {
+              if (imgUploadInput.current) {
+                imgUploadInput.current.click();
+              }
+            }}
+          ></SImg>
+        </>
+      )}
+
       <SImgInput
         type="file"
         id="img"

--- a/client/src/components/NewRecipe/ThumbNailUploader.tsx
+++ b/client/src/components/NewRecipe/ThumbNailUploader.tsx
@@ -11,11 +11,9 @@ const SImgInputContainer = styled.div`
 `;
 
 const SUserImg = styled.img`
-  display: inline-block;
-  overflow: hidden;
-  position: relative;
-  box-sizing: border-box;
   background-color: var(--pale-gray);
+  object-fit: cover; // 비율 조정
+  overflow: hidden;
   width: 150px;
   height: 150px;
   border-radius: 50%;

--- a/client/src/types/interface.ts
+++ b/client/src/types/interface.ts
@@ -3,6 +3,7 @@ import { TypeOfFileList, TypeOfFormData, TypeOfIngredients } from "./type";
 import { UseFormRegister } from "react-hook-form";
 
 interface IThumbNailProps {
+  isMypage?: boolean;
   resThumbNailImgUrl?: string;
   setThumbNail: Dispatch<SetStateAction<TypeOfFileList>>;
 }


### PR DESCRIPTION
## 1. 작업 내용
- 마이페이지에서 사용자 프로필 변경할 수있습니다.
- 응답에 따라 에러, 성공 메세지가 노출됩니다.
- 사진 변경 없이 프로필 수정을 누르면 수정 이미지 선택을 유도하는 메세지가 노출됩니다.
<img width="362" alt="image" src="https://user-images.githubusercontent.com/90553688/195099346-23cbc1ab-9831-4310-ba10-60db5ac5108c.png">
<img width="363" alt="image" src="https://user-images.githubusercontent.com/90553688/195099420-00c4184d-ecb8-4525-ab25-2a20b56b8a35.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/90553688/195099533-5c4832b2-aad1-4b64-80c1-61f1b325ef1b.png">


## 2. 전달사항
- 임시로 회원정보수정 대신 프로필 수정 버튼으로 수정했습니다.
- 사용자 정보 수정 페이지 추가시 해당 이미지 업로드 모듈은 이동해주시고, 마이페이지에는 img 로 변경해주시면 됩니다.
- 혹시 이미지 업로드 컴포넌트 수정하게되면 등록페이지나 수정페이지에도 같이 사용하고 있어서 주의해주세요
